### PR TITLE
Changeset release/latest

### DIFF
--- a/.changeset/nice-wasps-relax.md
+++ b/.changeset/nice-wasps-relax.md
@@ -1,7 +1,0 @@
----
-'@fluent-blocks/basic-icons': major
-'@fluent-blocks/react': major
-'@fluent-blocks/schemas': major
----
-
-Initial release.

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Publish to NPM
         uses: changesets/action@v1
         with:
+          version: pnpm changeset:version
           publish: pnpm publish:latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Publish to NPM
         uses: changesets/action@v1
         with:
+          version: pnpm changeset:version
           publish: pnpm publish:next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint-staged": "lint-staged",
     "test": "pnpm run test -r --if-present",
     "changeset:add": "pnpm exec changeset add",
-    "changeset:version": "pnpm exec changeset version",
+    "changeset:version": "pnpm exec changeset version && pnpm install --lockfile-only",
     "publish:latest": "pnpm exec changeset publish",
     "publish:next": "pnpm exec changeset pre enter next && pnpm exec changeset publish --tag next && pnpm exec changeset exit next"
   },

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @fluent-blocks/basic-icons
+
+## 9.0.0
+
+### Major Changes
+
+- [`7a2eef4`](https://github.com/OfficeDev/fluent-blocks/commit/7a2eef432ed5a088f8f86bfb74303fdc81e287fc) Thanks [@thure](https://github.com/thure)! - Initial release.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,13 +1,17 @@
 {
   "name": "@fluent-blocks/basic-icons",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "repository": "git@github.com:OfficeDev/fluent-blocks.git",
   "authors": [
     "Will Shown <willshown@microsoft.com>"
   ],
   "license": "MIT",
   "main": "basic-icons.json",
-  "files": ["basic-icons.json", "basic-icons.svg", "scripts/postinstall.js"],
+  "files": [
+    "basic-icons.json",
+    "basic-icons.svg",
+    "scripts/postinstall.js"
+  ],
   "scripts": {
     "bundle": "touch ./basic-icons.svg && fluentui-svg-icon-sprites bundle -i ./basic-icons.json -s ./node_modules/fluentui-svg-icon-sprites/icons -o ./basic-icons.svg",
     "postinstall": "node ./scripts/postinstall.js"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @fluent-blocks/react
+
+## 9.0.0
+
+### Major Changes
+
+- [`7a2eef4`](https://github.com/OfficeDev/fluent-blocks/commit/7a2eef432ed5a088f8f86bfb74303fdc81e287fc) Thanks [@thure](https://github.com/thure)! - Initial release.
+
+### Patch Changes
+
+- Updated dependencies [[`7a2eef4`](https://github.com/OfficeDev/fluent-blocks/commit/7a2eef432ed5a088f8f86bfb74303fdc81e287fc)]:
+  - @fluent-blocks/basic-icons@9.0.0
+  - @fluent-blocks/schemas@9.0.0

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluent-blocks/react",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "repository": "git@github.com:OfficeDev/fluent-blocks.git",
   "authors": [
     "Will Shown <willshown@microsoft.com>",
@@ -79,8 +79,8 @@
     "webpack": "latest"
   },
   "dependencies": {
-    "@fluent-blocks/basic-icons": "workspace:8.0.0",
-    "@fluent-blocks/schemas": "workspace:8.0.0",
+    "@fluent-blocks/basic-icons": "workspace:9.0.0",
+    "@fluent-blocks/schemas": "workspace:9.0.0",
     "@fluentui/react-tabster": "latest",
     "lodash": "latest"
   }

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @fluent-blocks/schemas
+
+## 9.0.0
+
+### Major Changes
+
+- [`7a2eef4`](https://github.com/OfficeDev/fluent-blocks/commit/7a2eef432ed5a088f8f86bfb74303fdc81e287fc) Thanks [@thure](https://github.com/thure)! - Initial release.

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@fluent-blocks/schemas",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "main": "index.d.ts",
   "types": "types/index.d.ts",
-  "files": [ "types" ],
+  "files": [
+    "types"
+  ],
   "repository": "git@github.com:OfficeDev/fluent-blocks.git",
   "authors": [
     "Will Shown <willshown@microsoft.com>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
   packages/react:
     specifiers:
       '@babel/core': latest
-      '@fluent-blocks/basic-icons': workspace:8.0.0
-      '@fluent-blocks/schemas': workspace:8.0.0
+      '@fluent-blocks/basic-icons': workspace:9.0.0
+      '@fluent-blocks/schemas': workspace:9.0.0
       '@fluentui/react-components': latest
       '@fluentui/react-tabster': latest
       '@storybook/addon-actions': next


### PR DESCRIPTION
This is a successor of #93 which attempts to fix the lockfile issue blocking release.

# Releases
## @fluent-blocks/basic-icons@9.0.0

### Major Changes

-   [`7a2eef4`](https://github.com/OfficeDev/fluent-blocks/commit/7a2eef432ed5a088f8f86bfb74303fdc81e287fc) Thanks [@thure](https://github.com/thure)! - Initial release.

 ## @fluent-blocks/react@9.0.0

### Major Changes

-   [`7a2eef4`](https://github.com/OfficeDev/fluent-blocks/commit/7a2eef432ed5a088f8f86bfb74303fdc81e287fc) Thanks [@thure](https://github.com/thure)! - Initial release.

### Patch Changes

-   Updated dependencies \[[`7a2eef4`](https://github.com/OfficeDev/fluent-blocks/commit/7a2eef432ed5a088f8f86bfb74303fdc81e287fc)]:
    -   @fluent-blocks/basic-icons@9.0.0
    -   @fluent-blocks/schemas@9.0.0

 ## @fluent-blocks/schemas@9.0.0

### Major Changes

-   [`7a2eef4`](https://github.com/OfficeDev/fluent-blocks/commit/7a2eef432ed5a088f8f86bfb74303fdc81e287fc) Thanks [@thure](https://github.com/thure)! - Initial release.
