### PR TITLE
Fix diff threshold

### DIFF
--- a/.changeset/forty-files-jump.md
+++ b/.changeset/forty-files-jump.md
@@ -1,0 +1,5 @@
+---
+'@fluent-blocks/react': patch
+---
+
+Make UI tests with Charts less flaky.

--- a/packages/react/src/blocks/Card/Card.stories.mdx
+++ b/packages/react/src/blocks/Card/Card.stories.mdx
@@ -134,7 +134,7 @@ used to group content as a regular Block element as well.
         },
       },
     }}
-    parameters={{ chromatic: { delay: 1000 } }}
+    parameters={{ chromatic: { delay: 1000, diffThreshold: 0.2 } }}
   >
     {seed(1234) || CardLayoutTemplate.bind({})}
   </Story>

--- a/packages/react/src/blocks/Layout/Layout.stories.mdx
+++ b/packages/react/src/blocks/Layout/Layout.stories.mdx
@@ -201,7 +201,7 @@ The `Layout` component is a block which can arrange its content items such that 
         ],
       },
     }}
-    parameters={{ chromatic: { delay: 1000 } }}
+    parameters={{ chromatic: { delay: 1000, diffThreshold: 0.2 } }}
   >
     {seed(1234) || LayoutTemplate.bind({})}
   </Story>

--- a/packages/react/src/blocks/Toolbar/Toolbar.stories.mdx
+++ b/packages/react/src/blocks/Toolbar/Toolbar.stories.mdx
@@ -33,7 +33,7 @@ import { Toolbar } from './StorybookToolbar'
     },
   }}
   parameters={{
-    chromatic: { delay: 2000 },
+    chromatic: { delay: 3000, diffThreshold: 0.2 },
   }}
 />
 

--- a/packages/react/src/media/Chart/Chart.stories.mdx
+++ b/packages/react/src/media/Chart/Chart.stories.mdx
@@ -9,7 +9,7 @@ import { Chart } from './StorybookChart'
   component={Chart}
   parameters={{
     viewMode: 'docs',
-    chromatic: { delay: 1000 },
+    chromatic: { delay: 1000, diffThreshold: 0.2 },
   }}
   argTypes={{
     ...contextArgTypes,


### PR DESCRIPTION
This sets a greater `diffThreshold` (https://www.chromatic.com/docs/threshold) for UI test stories containing Charts.

This PR also tries to stabilize the Toolbar UI test story by doing the same and lengthening its delay.