### PR TITLE
Fix CI for basic-icons package

### DIFF
--- a/.changeset/odd-countries-sell.md
+++ b/.changeset/odd-countries-sell.md
@@ -1,0 +1,5 @@
+---
+'@fluent-blocks/basic-icons': patch
+---
+
+Ensure basic-icons sprite is built in CI before publishing.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -13,6 +13,7 @@
     "scripts/postinstall.js"
   ],
   "scripts": {
+    "prepublishOnly": "pnpm bundle",
     "bundle": "touch ./basic-icons.svg && fluentui-svg-icon-sprites bundle -i ./basic-icons.json -s ./node_modules/fluentui-svg-icon-sprites/icons -o ./basic-icons.svg",
     "postinstall": "node ./scripts/postinstall.js"
   },


### PR DESCRIPTION
The basic-icons.svg sprite wasn't being built in CI, though there's no reason it shouldn't be. This PR fixes that.