### PR TITLE
Improve surfaces ontology

### DIFF
--- a/.changeset/eighty-walls-deny.md
+++ b/.changeset/eighty-walls-deny.md
@@ -1,5 +1,6 @@
 ---
 '@fluent-blocks/react': minor
+'@fluent-blocks/schemas': minor
 ---
 
 Improve the ontology for Topbar and Sidebar; Topbar now supports a menu on its `far` prop, and Sidebar now uses an implicit Accordion and expects a title.

--- a/.changeset/eighty-walls-deny.md
+++ b/.changeset/eighty-walls-deny.md
@@ -1,0 +1,5 @@
+---
+'@fluent-blocks/react': minor
+---
+
+Improve the ontology for Topbar and Sidebar; Topbar now supports a menu on its `far` prop, and Sidebar now uses an implicit Accordion and expects a title.

--- a/packages/react/src/blocks/Toolbar/Toolbar.tsx
+++ b/packages/react/src/blocks/Toolbar/Toolbar.tsx
@@ -36,6 +36,7 @@ export interface ToolbarProps extends Omit<NaturalToolbarProps, 'toolbar'> {
   contextualFindProps?: {
     onAction: (payload: SingleValueInputActionPayload) => void
   }
+  contextualJustifyEnd?: boolean
 }
 
 type ToolbarItemContextualOptions = Pick<
@@ -57,6 +58,8 @@ const useToolbarStyles = makeStyles({
     display: 'flex',
     flexWrap: 'wrap',
     flexGrow: 1,
+    flexShrink: 0,
+    flexBasis: rem(48),
   },
   find: {
     flexGrow: 1,
@@ -71,6 +74,9 @@ const useToolbarStyles = makeStyles({
   },
   'root--large': {
     height: rem(40),
+  },
+  'root--justifyEnd': {
+    flexDirection: 'row-reverse',
   },
   flexDivider: {
     flexGrow: 1,
@@ -112,6 +118,7 @@ export const Toolbar = ({
   toolbar,
   contextualVariant = 'block',
   contextualFindProps,
+  contextualJustifyEnd,
 }: ToolbarProps) => {
   const commonStyles = useCommonStyles()
   const toolbarStyles = useToolbarStyles()
@@ -170,6 +177,7 @@ export const Toolbar = ({
       className={cx(
         toolbarStyles.root,
         toolbarStyles[`root--${toolbar.buttonSize || defaultButtonSize}`],
+        contextualJustifyEnd && toolbarStyles['root--justifyEnd'],
         contextualVariant === 'block' && commonStyles.mainContentWidth,
         contextualVariant === 'block' && commonStyles.centerBlock
       )}

--- a/packages/react/src/surfaces/Sidebar/Sidebar.stories.mdx
+++ b/packages/react/src/surfaces/Sidebar/Sidebar.stories.mdx
@@ -60,6 +60,7 @@ narrow to display the Sidebar next to the Main content.
       themeName: 'light',
       accentScheme: 'teams',
       sidebar: {
+        title: fakeTitle(fake),
         menu: range(8).map((s) => ({
           type: 'action',
           actionId: `sidebar-action__${s}`,

--- a/packages/react/src/surfaces/Sidebar/Sidebar.stories.mdx
+++ b/packages/react/src/surfaces/Sidebar/Sidebar.stories.mdx
@@ -61,10 +61,14 @@ narrow to display the Sidebar next to the Main content.
       accentScheme: 'teams',
       sidebar: {
         title: fakeTitle(fake),
-        menu: range(8).map((s) => ({
-          type: 'action',
-          actionId: `sidebar-action__${s}`,
+        items: range(3).map((i) => ({
+          actionId: `sidebar-item__${i}`,
           label: fakeTitle(fake),
+          menu: range(6).map((s) => ({
+            type: 'action',
+            actionId: `sidebar-action__${i}-${s}`,
+            label: fakeTitle(fake),
+          })),
         })),
       },
       main: mainArgs,

--- a/packages/react/src/surfaces/Sidebar/Sidebar.tsx
+++ b/packages/react/src/surfaces/Sidebar/Sidebar.tsx
@@ -9,7 +9,6 @@ import { InlineSequenceOrString } from '../../inlines'
 import { Button, ButtonProps } from '../../inputs'
 import { rem, sx, useCommonStyles, useFluentBlocksContext } from '../../lib'
 import { ContextualViewStateProps, SidebarState } from '../../props'
-import { topbarHeight } from '../Topbar/topbarHeight'
 import { sidebarWidth } from './sidebarWidth'
 
 export interface SidebarProps
@@ -47,9 +46,6 @@ const useSidebarStyles = makeStyles({
   },
   'inner--hc': {
     borderInlineEndColor: 'var(--colorNeutralForeground1)',
-  },
-  sidebarTopbar: {
-    height: rem(topbarHeight),
   },
   paddedContent: {
     marginInlineEnd: rem(-8),

--- a/packages/react/src/surfaces/Sidebar/Sidebar.tsx
+++ b/packages/react/src/surfaces/Sidebar/Sidebar.tsx
@@ -109,26 +109,26 @@ export const Sidebar = ({
           }
         >
           {items.map(({ actionId, label, menu }) => (
-              <AccordionItem key={actionId} value={actionId}>
-                <AccordionHeader>
-                  <InlineContent inlines={label} />
-                </AccordionHeader>
-                <AccordionPanel>
-                  {menu.map((menuItem) => {
-                    if (menuItem.type === 'action') {
-                      return (
-                        <Button
-                          key={menuItem.actionId}
-                          {...menuItem}
-                          variant="subtle"
-                          contextualVariant="sidebar"
-                        />
-                      )
-                    }
-                  })}
-                </AccordionPanel>
-              </AccordionItem>
-            ))}
+            <AccordionItem key={actionId} value={actionId}>
+              <AccordionHeader as="h2">
+                <InlineContent inlines={label} />
+              </AccordionHeader>
+              <AccordionPanel>
+                {menu.map((menuItem) => {
+                  if (menuItem.type === 'action') {
+                    return (
+                      <Button
+                        key={menuItem.actionId}
+                        {...menuItem}
+                        variant="subtle"
+                        contextualVariant="sidebar"
+                      />
+                    )
+                  }
+                })}
+              </AccordionPanel>
+            </AccordionItem>
+          ))}
         </Accordion>
       </div>
     </div>

--- a/packages/react/src/surfaces/Sidebar/Sidebar.tsx
+++ b/packages/react/src/surfaces/Sidebar/Sidebar.tsx
@@ -4,15 +4,19 @@ import { Dispatch, SetStateAction, useCallback } from 'react'
 import { SidebarProps as NaturalSidebarProps } from '@fluent-blocks/schemas'
 import { mergeClasses as cx, makeStyles } from '@fluentui/react-components'
 
+import { Heading } from '../../blocks'
+import { InlineSequenceOrString } from '../../inlines'
 import { Button, ButtonProps } from '../../inputs'
 import { rem, sx, useCommonStyles, useFluentBlocksContext } from '../../lib'
 import { ContextualViewStateProps, SidebarState } from '../../props'
+import { topbarHeight } from '../Topbar/topbarHeight'
+import { sidebarWidth } from './sidebarWidth'
 
 export interface SidebarProps
-  extends NaturalSidebarProps,
-    ContextualViewStateProps {}
-
-export const sidebarWidth = 228
+  extends Omit<NaturalSidebarProps, 'title'>,
+    ContextualViewStateProps {
+  title: InlineSequenceOrString
+}
 
 const useSidebarStyles = makeStyles({
   root: {
@@ -36,7 +40,7 @@ const useSidebarStyles = makeStyles({
     overflowY: 'auto',
     overflowX: 'hidden',
     height: '100%',
-    ...sx.padding(rem(8)),
+    ...sx.padding(rem(16)),
     borderInlineEndWidth: '1px',
     borderInlineEndStyle: 'solid',
     borderInlineEndColor: 'transparent',
@@ -44,13 +48,19 @@ const useSidebarStyles = makeStyles({
   'inner--hc': {
     borderInlineEndColor: 'var(--colorNeutralForeground1)',
   },
+  sidebarTopbar: {
+    height: rem(topbarHeight),
+  },
+  paddedContent: {
+    marginInlineEnd: rem(-8),
+    marginInlineStart: rem(-8),
+  },
 })
 
-export const Sidebar = (props: SidebarProps) => {
+export const Sidebar = ({ title, menu, contextualViewState }: SidebarProps) => {
   const sidebarStyles = useSidebarStyles()
   const commonStyles = useCommonStyles()
   const { themeName } = useFluentBlocksContext()
-  const { contextualViewState } = props
   return (
     <div
       className={cx(
@@ -68,18 +78,21 @@ export const Sidebar = (props: SidebarProps) => {
           themeName === 'highContrast' && sidebarStyles['inner--hc']
         )}
       >
-        {props.menu?.map((menuItem) => {
-          if (menuItem.type === 'action') {
-            return (
-              <Button
-                key={menuItem.actionId}
-                {...menuItem}
-                variant="subtle"
-                contextualVariant="sidebar"
-              />
-            )
-          }
-        })}
+        <Heading paragraph={title} level={1} contextualVariant="card" />
+        <div className={sidebarStyles.paddedContent}>
+          {menu?.map((menuItem) => {
+            if (menuItem.type === 'action') {
+              return (
+                <Button
+                  key={menuItem.actionId}
+                  {...menuItem}
+                  variant="subtle"
+                  contextualVariant="sidebar"
+                />
+              )
+            }
+          })}
+        </div>
       </div>
     </div>
   )

--- a/packages/react/src/surfaces/Sidebar/Sidebar.tsx
+++ b/packages/react/src/surfaces/Sidebar/Sidebar.tsx
@@ -1,20 +1,41 @@
 import noop from 'lodash/noop'
 import { Dispatch, SetStateAction, useCallback } from 'react'
 
-import { SidebarProps as NaturalSidebarProps } from '@fluent-blocks/schemas'
-import { mergeClasses as cx, makeStyles } from '@fluentui/react-components'
+import {
+  SidebarItemProps as NaturalSidebarItemProps,
+  SidebarProps as NaturalSidebarProps,
+} from '@fluent-blocks/schemas'
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+  mergeClasses as cx,
+  makeStyles,
+} from '@fluentui/react-components'
 
 import { Heading } from '../../blocks'
-import { InlineSequenceOrString } from '../../inlines'
+import { InlineContent, InlineSequenceOrString } from '../../inlines'
 import { Button, ButtonProps } from '../../inputs'
 import { rem, sx, useCommonStyles, useFluentBlocksContext } from '../../lib'
-import { ContextualViewStateProps, SidebarState } from '../../props'
+import {
+  ContextualViewStateProps,
+  MenuItemSequence,
+  SidebarState,
+} from '../../props'
 import { sidebarWidth } from './sidebarWidth'
 
+export interface SidebarItemProps
+  extends Omit<NaturalSidebarItemProps, 'label' | 'menu'> {
+  label: InlineSequenceOrString
+  menu: MenuItemSequence
+}
+
 export interface SidebarProps
-  extends Omit<NaturalSidebarProps, 'title'>,
+  extends Omit<NaturalSidebarProps, 'title' | 'items'>,
     ContextualViewStateProps {
   title: InlineSequenceOrString
+  items: SidebarItemProps[]
 }
 
 const useSidebarStyles = makeStyles({
@@ -48,12 +69,17 @@ const useSidebarStyles = makeStyles({
     borderInlineEndColor: 'var(--colorNeutralForeground1)',
   },
   paddedContent: {
-    marginInlineEnd: rem(-8),
-    marginInlineStart: rem(-8),
+    marginInlineEnd: rem(-16),
+    marginInlineStart: rem(-16),
   },
 })
 
-export const Sidebar = ({ title, menu, contextualViewState }: SidebarProps) => {
+export const Sidebar = ({
+  title,
+  items,
+  defaultOpenItems,
+  contextualViewState,
+}: SidebarProps) => {
   const sidebarStyles = useSidebarStyles()
   const commonStyles = useCommonStyles()
   const { themeName } = useFluentBlocksContext()
@@ -75,20 +101,35 @@ export const Sidebar = ({ title, menu, contextualViewState }: SidebarProps) => {
         )}
       >
         <Heading paragraph={title} level={1} contextualVariant="card" />
-        <div className={sidebarStyles.paddedContent}>
-          {menu?.map((menuItem) => {
-            if (menuItem.type === 'action') {
-              return (
-                <Button
-                  key={menuItem.actionId}
-                  {...menuItem}
-                  variant="subtle"
-                  contextualVariant="sidebar"
-                />
-              )
-            }
-          })}
-        </div>
+        <Accordion
+          multiple
+          className={sidebarStyles.paddedContent}
+          defaultOpenItems={
+            defaultOpenItems || items.map(({ actionId }) => actionId)
+          }
+        >
+          {items.map(({ actionId, label, menu }) => (
+              <AccordionItem key={actionId} value={actionId}>
+                <AccordionHeader>
+                  <InlineContent inlines={label} />
+                </AccordionHeader>
+                <AccordionPanel>
+                  {menu.map((menuItem) => {
+                    if (menuItem.type === 'action') {
+                      return (
+                        <Button
+                          key={menuItem.actionId}
+                          {...menuItem}
+                          variant="subtle"
+                          contextualVariant="sidebar"
+                        />
+                      )
+                    }
+                  })}
+                </AccordionPanel>
+              </AccordionItem>
+            ))}
+        </Accordion>
       </div>
     </div>
   )

--- a/packages/react/src/surfaces/Sidebar/index.ts
+++ b/packages/react/src/surfaces/Sidebar/index.ts
@@ -1,0 +1,2 @@
+export * from './Sidebar'
+export * from './sidebarWidth'

--- a/packages/react/src/surfaces/Sidebar/sidebarWidth.ts
+++ b/packages/react/src/surfaces/Sidebar/sidebarWidth.ts
@@ -1,0 +1,1 @@
+export const sidebarWidth = 228

--- a/packages/react/src/surfaces/Topbar/Topbar.stories.mdx
+++ b/packages/react/src/surfaces/Topbar/Topbar.stories.mdx
@@ -42,6 +42,42 @@ export const mainArgs = {
   })),
 }
 
+export const topbarArgs = {
+  near: {
+    menu: [
+      {
+        type: 'action',
+        actionId: 'add',
+        label: 'Add',
+        icon: 'add',
+      },
+      {
+        type: 'action',
+        actionId: 'delete',
+        label: 'Delete',
+        icon: 'delete',
+      },
+    ],
+  },
+  far: {
+    menu: [
+      {
+        type: 'action',
+        actionId: 'publish',
+        label: 'Publish',
+        variant: 'primary',
+        icon: 'send',
+      },
+      {
+        type: 'action',
+        actionId: 'preview',
+        label: 'Preview',
+        icon: 'eye',
+      },
+    ],
+  },
+}
+
 # Topbar
 
 The Topbar is unique to a view (so `topbar` is one of `View`’s props). It
@@ -55,18 +91,7 @@ like a regular `Toolbar`.
     args={{
       themeName: 'light',
       accentScheme: 'teams',
-      topbar: {
-        near: {
-          menu: [
-            {
-              type: 'action',
-              actionId: 'hello',
-              label: 'Hello',
-              variant: 'primary',
-            },
-          ],
-        },
-      },
+      topbar: topbarArgs,
       main: mainArgs,
     }}
   >
@@ -86,18 +111,7 @@ will also add notifications to the far side of the Topbar.
     args={{
       themeName: 'light',
       accentScheme: 'teams',
-      topbar: {
-        near: {
-          menu: [
-            {
-              type: 'action',
-              actionId: 'hello',
-              label: 'Hello',
-              variant: 'primary',
-            },
-          ],
-        },
-      },
+      topbar: topbarArgs,
       sidebar: {
         menu: range(8).map((s) => ({
           type: 'action',

--- a/packages/react/src/surfaces/Topbar/Topbar.stories.mdx
+++ b/packages/react/src/surfaces/Topbar/Topbar.stories.mdx
@@ -113,6 +113,7 @@ will also add notifications to the far side of the Topbar.
       accentScheme: 'teams',
       topbar: topbarArgs,
       sidebar: {
+        title: fakeTitle(fake),
         menu: range(8).map((s) => ({
           type: 'action',
           actionId: `sidebar-action__${s}`,

--- a/packages/react/src/surfaces/Topbar/Topbar.stories.mdx
+++ b/packages/react/src/surfaces/Topbar/Topbar.stories.mdx
@@ -114,10 +114,14 @@ will also add notifications to the far side of the Topbar.
       topbar: topbarArgs,
       sidebar: {
         title: fakeTitle(fake),
-        menu: range(8).map((s) => ({
-          type: 'action',
-          actionId: `sidebar-action__${s}`,
+        items: range(3).map((i) => ({
+          actionId: `sidebar-item__${i}`,
           label: fakeTitle(fake),
+          menu: range(6).map((s) => ({
+            type: 'action',
+            actionId: `sidebar-action__${i}-${s}`,
+            label: fakeTitle(fake),
+          })),
         })),
       },
       main: mainArgs,

--- a/packages/react/src/surfaces/Topbar/Topbar.tsx
+++ b/packages/react/src/surfaces/Topbar/Topbar.tsx
@@ -43,9 +43,6 @@ const useTopbarStyles = makeStyles({
   'inner--hc': {
     borderBlockEndColor: 'var(--colorNeutralForeground1)',
   },
-  gap: {
-    ...sx.flex(1, 0, '0'),
-  },
 })
 
 export const Topbar = ({ near, far, contextualViewState }: TopbarProps) => {
@@ -76,10 +73,18 @@ export const Topbar = ({ near, far, contextualViewState }: TopbarProps) => {
         {hasSidebarInvoker && (
           <Button {...sidebarInvokerAction} variant="subtle" />
         )}
-        {near?.menu ? (
-          <Toolbar toolbar={{ menu: near.menu }} />
-        ) : (
-          <div role="none" className={topbarStyles.gap} />
+        {near?.menu && (
+          <Toolbar
+            toolbar={{ menu: near.menu }}
+            contextualVariant="viewportWidth"
+          />
+        )}
+        {far?.menu && (
+          <Toolbar
+            toolbar={{ menu: far.menu }}
+            contextualVariant="viewportWidth"
+            contextualJustifyEnd
+          />
         )}
       </div>
     </div>

--- a/packages/react/src/surfaces/Topbar/Topbar.tsx
+++ b/packages/react/src/surfaces/Topbar/Topbar.tsx
@@ -11,7 +11,7 @@ export interface TopbarProps
   extends NaturalTopbarProps,
     ContextualViewStateProps {}
 
-export const topbarHeight = 49
+export const topbarHeight = 48
 
 const useTopbarStyles = makeStyles({
   root: {
@@ -31,7 +31,7 @@ const useTopbarStyles = makeStyles({
   inner: {
     backgroundColor: 'var(--surface-background)',
     color: 'var(--surface-foreground)',
-    ...sx.padding(rem(8)),
+    ...sx.padding(rem(8), rem(8), rem(7), rem(8)),
     borderBlockEndWidth: '1px',
     borderBlockEndStyle: 'solid',
     borderBlockEndColor: 'transparent',

--- a/packages/react/src/surfaces/Topbar/Topbar.tsx
+++ b/packages/react/src/surfaces/Topbar/Topbar.tsx
@@ -40,6 +40,12 @@ const useTopbarStyles = makeStyles({
     display: 'flex',
     ...sx.gap(rem(4)),
   },
+  nonInvokerInner: {
+    display: 'contents',
+  },
+  'nonInvokerInner--sidebarActive': {
+    visibility: 'hidden',
+  },
   'inner--hc': {
     borderBlockEndColor: 'var(--colorNeutralForeground1)',
   },
@@ -73,19 +79,27 @@ export const Topbar = ({ near, far, contextualViewState }: TopbarProps) => {
         {hasSidebarInvoker && (
           <Button {...sidebarInvokerAction} variant="subtle" />
         )}
-        {near?.menu && (
-          <Toolbar
-            toolbar={{ menu: near.menu }}
-            contextualVariant="viewportWidth"
-          />
-        )}
-        {far?.menu && (
-          <Toolbar
-            toolbar={{ menu: far.menu }}
-            contextualVariant="viewportWidth"
-            contextualJustifyEnd
-          />
-        )}
+        <div
+          className={cx(
+            topbarStyles.nonInvokerInner,
+            sidebarState === SidebarState.Active &&
+              topbarStyles['nonInvokerInner--sidebarActive']
+          )}
+        >
+          {near?.menu && (
+            <Toolbar
+              toolbar={{ menu: near.menu }}
+              contextualVariant="viewportWidth"
+            />
+          )}
+          {far?.menu && (
+            <Toolbar
+              toolbar={{ menu: far.menu }}
+              contextualVariant="viewportWidth"
+              contextualJustifyEnd
+            />
+          )}
+        </div>
       </div>
     </div>
   )

--- a/packages/react/src/surfaces/Topbar/Topbar.tsx
+++ b/packages/react/src/surfaces/Topbar/Topbar.tsx
@@ -8,8 +8,6 @@ import { ContextualViewStateProps, SidebarState } from '../../props'
 import { sidebarWidth, useSidebarInvoker } from '../Sidebar'
 import { topbarHeight } from './topbarHeight'
 
-console.log('[sidebarWidth]', sidebarWidth)
-
 export interface TopbarProps
   extends NaturalTopbarProps,
     ContextualViewStateProps {}
@@ -60,10 +58,6 @@ export const Topbar = ({ near, far, contextualViewState }: TopbarProps) => {
   const hasSidebarInvoker =
     sidebarState === SidebarState.Active || sidebarState === SidebarState.Hidden
   const sidebarInvokerAction = useSidebarInvoker(contextualViewState)
-  console.log(
-    'sidebarState === SidebarState.Docked',
-    sidebarState === SidebarState.Docked
-  )
   return (
     <div
       className={cx(

--- a/packages/react/src/surfaces/Topbar/Topbar.tsx
+++ b/packages/react/src/surfaces/Topbar/Topbar.tsx
@@ -5,13 +5,14 @@ import { Toolbar } from '../../blocks/Toolbar/Toolbar'
 import { Button } from '../../inputs'
 import { rem, sx, useCommonStyles, useFluentBlocksContext } from '../../lib'
 import { ContextualViewStateProps, SidebarState } from '../../props'
-import { sidebarWidth, useSidebarInvoker } from '../Sidebar/Sidebar'
+import { sidebarWidth, useSidebarInvoker } from '../Sidebar'
+import { topbarHeight } from './topbarHeight'
+
+console.log('[sidebarWidth]', sidebarWidth)
 
 export interface TopbarProps
   extends NaturalTopbarProps,
     ContextualViewStateProps {}
-
-export const topbarHeight = 48
 
 const useTopbarStyles = makeStyles({
   root: {
@@ -59,6 +60,10 @@ export const Topbar = ({ near, far, contextualViewState }: TopbarProps) => {
   const hasSidebarInvoker =
     sidebarState === SidebarState.Active || sidebarState === SidebarState.Hidden
   const sidebarInvokerAction = useSidebarInvoker(contextualViewState)
+  console.log(
+    'sidebarState === SidebarState.Docked',
+    sidebarState === SidebarState.Docked
+  )
   return (
     <div
       className={cx(

--- a/packages/react/src/surfaces/Topbar/index.ts
+++ b/packages/react/src/surfaces/Topbar/index.ts
@@ -1,0 +1,2 @@
+export * from './Topbar'
+export * from './topbarHeight'

--- a/packages/react/src/surfaces/Topbar/topbarHeight.ts
+++ b/packages/react/src/surfaces/Topbar/topbarHeight.ts
@@ -1,0 +1,1 @@
+export const topbarHeight = 48

--- a/packages/react/src/surfaces/index.ts
+++ b/packages/react/src/surfaces/index.ts
@@ -1,3 +1,3 @@
 export * from './Main/Main'
-export * from './Sidebar/Sidebar'
-export * from './Topbar/Topbar'
+export * from './Sidebar'
+export * from './Topbar'

--- a/packages/schemas/types/surfaces/Sidebar.d.ts
+++ b/packages/schemas/types/surfaces/Sidebar.d.ts
@@ -1,5 +1,7 @@
+import { InlineSequenceOrString } from '../inlines'
 import { MenuItemSequence } from '../lib/menu'
 
 export interface SidebarProps {
+  title: InlineSequenceOrString
   menu: MenuItemSequence
 }

--- a/packages/schemas/types/surfaces/Sidebar.d.ts
+++ b/packages/schemas/types/surfaces/Sidebar.d.ts
@@ -1,7 +1,14 @@
 import { InlineSequenceOrString } from '../inlines'
 import { MenuItemSequence } from '../lib/menu'
 
+export interface SidebarItemProps {
+  actionId: string
+  label: InlineSequenceOrString
+  menu: MenuItemSequence
+}
+
 export interface SidebarProps {
   title: InlineSequenceOrString
-  menu: MenuItemSequence
+  items: SidebarItemProps[]
+  defaultOpenItems?: string[]
 }

--- a/packages/schemas/types/surfaces/Topbar.d.ts
+++ b/packages/schemas/types/surfaces/Topbar.d.ts
@@ -1,13 +1,7 @@
-import { FilterProps } from '../blocks'
 import { MenuItemSequence } from '../lib/menu'
 
 interface TopbarFarProps {
   menu?: MenuItemSequence
-  filter?: FilterProps
-  /**
-   * An actionId
-   */
-  find?: string
 }
 
 interface TopbarNearProps {


### PR DESCRIPTION
This PR extends the content ontologies of both the Topbar and the Sidebar:
- The Topbar now supports a menu on its `far` prop
- The Sidebar now uses an Accordion (which is not its own component in Fluent Blocks yet) and expects a `title`.

<img width="1125" alt="Screen Shot 2022-05-16 at 18 00 04" src="https://user-images.githubusercontent.com/855039/168706122-69094bf0-54d9-4f69-a630-74620024ff84.png">
