### PR TITLE
Fix Topbar & Sidebar roles

### DIFF
--- a/.changeset/grumpy-rice-clean.md
+++ b/.changeset/grumpy-rice-clean.md
@@ -1,0 +1,5 @@
+---
+'@fluent-blocks/react': patch
+---
+
+Fix roles for topbar and sidebar.

--- a/packages/react/src/blocks/Table/Table.tsx
+++ b/packages/react/src/blocks/Table/Table.tsx
@@ -389,6 +389,7 @@ export const Table = (props: TableProps) => {
                                         : 'arrow_down'
                                       : 'arrow_sort'
                                   }
+                                  contextualRole="button"
                                 />
                               )}
                           </div>

--- a/packages/react/src/blocks/Toolbar/Toolbar.tsx
+++ b/packages/react/src/blocks/Toolbar/Toolbar.tsx
@@ -202,6 +202,7 @@ export const Toolbar = ({
             }))
       )}
       <div
+        role="none"
         data-layout="required"
         className={cx(
           toolbarStyles.requiredInFlow,
@@ -214,10 +215,12 @@ export const Toolbar = ({
           contextualHiddenFlags={menuItemHiddenFlags}
           iconSize={toolbar.iconSize || defaultIconSize}
           buttonSize={toolbar.buttonSize || defaultButtonSize}
+          contextualRole="menuitem"
         />
       </div>
       {toolbar.find && (
         <div
+          role="none"
           data-layout="required"
           className={cx(
             toolbarStyles.requiredInFlow,

--- a/packages/react/src/blocks/Toolbar/Toolbar.tsx
+++ b/packages/react/src/blocks/Toolbar/Toolbar.tsx
@@ -1,4 +1,3 @@
-import debounce from 'lodash/debounce'
 import every from 'lodash/every'
 import get from 'lodash/get'
 import { ReactElement, useCallback, useRef, useState } from 'react'
@@ -37,6 +36,7 @@ export interface ToolbarProps extends Omit<NaturalToolbarProps, 'toolbar'> {
     onAction: (payload: SingleValueInputActionPayload) => void
   }
   contextualJustifyEnd?: boolean
+  contextualRole?: 'menubar' | 'group'
 }
 
 type ToolbarItemContextualOptions = Pick<
@@ -108,6 +108,7 @@ const ToolbarItemInFlow = (
           ? 'toolbar-item--hidden'
           : 'toolbar-item',
         type: 'action',
+        contextualRole: 'menuitem',
       })
     default:
       return null
@@ -119,6 +120,7 @@ export const Toolbar = ({
   contextualVariant = 'block',
   contextualFindProps,
   contextualJustifyEnd,
+  contextualRole = 'menubar',
 }: ToolbarProps) => {
   const commonStyles = useCommonStyles()
   const toolbarStyles = useToolbarStyles()
@@ -174,6 +176,7 @@ export const Toolbar = ({
 
   return (
     <div
+      role={contextualRole}
       className={cx(
         toolbarStyles.root,
         toolbarStyles[`root--${toolbar.buttonSize || defaultButtonSize}`],

--- a/packages/react/src/inputs/Button/Button.tsx
+++ b/packages/react/src/inputs/Button/Button.tsx
@@ -20,7 +20,9 @@ export type ButtonActionPayload = NaturalButtonActionPayload
 export interface ButtonProps
   extends NaturalButtonProps,
     WithActionHandler<ButtonActionPayload>,
-    ShortInputContextualProps {}
+    ShortInputContextualProps {
+  contextualRole?: 'button' | 'menuitem'
+}
 
 const useButtonStyles = makeStyles({
   root: {
@@ -64,6 +66,7 @@ export const Button = ({
   disabled,
   payload,
   contextualVariant = 'block-inputs',
+  contextualRole = 'button',
 }: ButtonProps) => {
   const { onAction: contextOnAction } = useFluentBlocksContext()
 
@@ -88,6 +91,7 @@ export const Button = ({
 
   const button = (
     <FluentButton
+      role={contextualRole}
       aria-label={label}
       appearance={variant}
       disabled={disabled}

--- a/packages/react/src/inputs/Overflow/Overflow.tsx
+++ b/packages/react/src/inputs/Overflow/Overflow.tsx
@@ -102,6 +102,7 @@ export const Overflow = ({
             className={overflowStyles.trigger}
             icon={<Icon icon={triggerIcon} size={iconSize} variant="outline" />}
             size={buttonSize}
+            role="menuitem"
           />
         </Tooltip>
       </MenuTrigger>

--- a/packages/react/src/inputs/Overflow/Overflow.tsx
+++ b/packages/react/src/inputs/Overflow/Overflow.tsx
@@ -26,6 +26,7 @@ export interface OverflowProps extends Omit<NaturalOverflowProps, 'overflow'> {
   contextualHiddenFlags?: { hidden?: boolean }[]
   triggerIcon?: string
   triggerLabel?: string
+  contextualRole?: 'button' | 'menuitem'
 }
 
 function isAction(o: any): o is MenuAction {
@@ -89,6 +90,7 @@ export const Overflow = ({
   contextualHiddenFlags,
   triggerIcon = 'more_horizontal',
   triggerLabel,
+  contextualRole,
 }: OverflowProps) => {
   const { translations, onAction } = useFluentBlocksContext()
   const overflowStyles = useOverflowStyles()
@@ -102,7 +104,7 @@ export const Overflow = ({
             className={overflowStyles.trigger}
             icon={<Icon icon={triggerIcon} size={iconSize} variant="outline" />}
             size={buttonSize}
-            role="menuitem"
+            role={contextualRole}
           />
         </Tooltip>
       </MenuTrigger>

--- a/packages/react/src/surfaces/Sidebar/Sidebar.tsx
+++ b/packages/react/src/surfaces/Sidebar/Sidebar.tsx
@@ -17,7 +17,13 @@ import {
 import { Heading } from '../../blocks'
 import { InlineContent, InlineSequenceOrString } from '../../inlines'
 import { Button, ButtonProps } from '../../inputs'
-import { rem, sx, useCommonStyles, useFluentBlocksContext } from '../../lib'
+import {
+  key,
+  rem,
+  sx,
+  useCommonStyles,
+  useFluentBlocksContext,
+} from '../../lib'
 import {
   ContextualViewStateProps,
   MenuItemSequence,
@@ -83,8 +89,10 @@ export const Sidebar = ({
   const sidebarStyles = useSidebarStyles()
   const commonStyles = useCommonStyles()
   const { themeName } = useFluentBlocksContext()
+  const labelId = key(title)
   return (
-    <div
+    <nav
+      aria-labelledby={labelId}
       className={cx(
         sidebarStyles.root,
         contextualViewState?.sidebarState === SidebarState.Active &&
@@ -94,13 +102,19 @@ export const Sidebar = ({
       )}
     >
       <div
+        role="none"
         className={cx(
           sidebarStyles.inner,
           commonStyles.elevatedSurface,
           themeName === 'highContrast' && sidebarStyles['inner--hc']
         )}
       >
-        <Heading paragraph={title} level={1} contextualVariant="card" />
+        <Heading
+          paragraph={title}
+          level={1}
+          contextualVariant="card"
+          contextualId={labelId}
+        />
         <Accordion
           multiple
           className={sidebarStyles.paddedContent}
@@ -113,7 +127,7 @@ export const Sidebar = ({
               <AccordionHeader as="h2">
                 <InlineContent inlines={label} />
               </AccordionHeader>
-              <AccordionPanel>
+              <AccordionPanel role="group">
                 {menu.map((menuItem) => {
                   if (menuItem.type === 'action') {
                     return (
@@ -131,7 +145,7 @@ export const Sidebar = ({
           ))}
         </Accordion>
       </div>
-    </div>
+    </nav>
   )
 }
 

--- a/packages/react/src/surfaces/Topbar/Topbar.tsx
+++ b/packages/react/src/surfaces/Topbar/Topbar.tsx
@@ -60,6 +60,7 @@ export const Topbar = ({ near, far, contextualViewState }: TopbarProps) => {
   const sidebarInvokerAction = useSidebarInvoker(contextualViewState)
   return (
     <div
+      role="menubar"
       className={cx(
         topbarStyles.root,
         sidebarState === SidebarState.Active &&
@@ -69,6 +70,7 @@ export const Topbar = ({ near, far, contextualViewState }: TopbarProps) => {
       )}
     >
       <div
+        role="none"
         className={cx(
           topbarStyles.inner,
           commonStyles.elevatedSurface,
@@ -79,6 +81,7 @@ export const Topbar = ({ near, far, contextualViewState }: TopbarProps) => {
           <Button {...sidebarInvokerAction} variant="subtle" />
         )}
         <div
+          role="none"
           className={cx(
             topbarStyles.nonInvokerInner,
             sidebarState === SidebarState.Active &&
@@ -89,6 +92,7 @@ export const Topbar = ({ near, far, contextualViewState }: TopbarProps) => {
             <Toolbar
               toolbar={{ menu: near.menu }}
               contextualVariant="viewportWidth"
+              contextualRole="group"
             />
           )}
           {far?.menu && (
@@ -96,6 +100,7 @@ export const Topbar = ({ near, far, contextualViewState }: TopbarProps) => {
               toolbar={{ menu: far.menu }}
               contextualVariant="viewportWidth"
               contextualJustifyEnd
+              contextualRole="group"
             />
           )}
         </div>


### PR DESCRIPTION
This aligns Topbar and Sidebar with MDN’s guidance on [menubar](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_role) and [navigation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role) roles respectively, also removing a lot of presentational elements from the accessibility tree.