### PR TITLE
Fix input value initial state

### DIFF
--- a/.changeset/cuddly-elephants-sip.md
+++ b/.changeset/cuddly-elephants-sip.md
@@ -1,0 +1,6 @@
+---
+'@fluent-blocks/schemas': minor
+'@fluent-blocks/react': patch
+---
+
+Change Sidebar to use initialActiveItem. Allow initialValue(s) to programmatically change input state.

--- a/packages/react/src/inputs/Select/variants/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/inputs/Select/variants/CheckboxGroup/CheckboxGroup.tsx
@@ -44,6 +44,7 @@ export const CheckboxGroup = ({
 
   useEffect(() => {
     putInputValue(actionId, initialValues || [])
+    setValues(new Set(initialValues))
     return () => deleteInputValue(actionId)
   }, [initialValues])
 

--- a/packages/react/src/inputs/Select/variants/Dropdown/Dropdown.tsx
+++ b/packages/react/src/inputs/Select/variants/Dropdown/Dropdown.tsx
@@ -1,5 +1,5 @@
 import get from 'lodash/get'
-import { ChangeEvent, useCallback, useEffect } from 'react'
+import { ChangeEvent, useCallback, useEffect, useState } from 'react'
 
 import { SingleValueInputActionPayload } from '@fluent-blocks/schemas'
 import { Select as FluentSelect } from '@fluentui/react-components/unstable'
@@ -54,22 +54,27 @@ export const Dropdown = ({
 }: DropdownProps) => {
   const { onAction: contextOnAction } = useFluentBlocksContext()
 
+  const [value, setValue] = useState<string>(initialValue || '')
+
   useEffect(() => {
-    putInputValue(actionId, initialValue || '')
+    const nextValue = initialValue || ''
+    putInputValue(actionId, nextValue)
+    setValue(nextValue)
     return () => deleteInputValue(actionId)
   }, [initialValue])
 
   const onChange = useCallback(
     ({ target }: ChangeEvent<HTMLSelectElement>) => {
-      const value = get(target, 'value', '')
-      if (value) {
-        putInputValue(actionId, value)
+      const nextValue = get(target, 'value', '')
+      setValue(nextValue)
+      if (nextValue) {
+        putInputValue(actionId, nextValue)
       }
       const actionPayload = makePayload<SingleValueInputActionPayload>(
         {
           actionId,
           type: 'change' as 'change',
-          value,
+          value: nextValue,
         },
         metadata,
         include
@@ -85,7 +90,7 @@ export const Dropdown = ({
       <FluentSelect
         {...{
           id: actionId,
-          defaultValue: initialValue || '',
+          value,
           onChange,
           ...(disambiguatingLabel
             ? { 'aria-label': disambiguatingLabel }
@@ -98,7 +103,8 @@ export const Dropdown = ({
           disabled
           {...(!initialValue && {
             // React errors about this, but provides no alternative means of
-            // selecting the falsy placeholder value when `initialValue` is falsy.
+            // selecting the falsy placeholder value when `initialValue`
+            // is falsy.
             selected: true,
           })}
         >

--- a/packages/react/src/inputs/Select/variants/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/inputs/Select/variants/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, Fragment, useCallback, useEffect } from 'react'
+import { FormEvent, Fragment, useCallback, useEffect, useState } from 'react'
 
 import { SingleValueInputActionPayload } from '@fluent-blocks/schemas'
 import {
@@ -43,19 +43,28 @@ export const RadioGroup = ({
 }: RadioGroupProps) => {
   const { onAction: contextOnAction } = useFluentBlocksContext()
 
+  const [value, setValue] = useState<string>(initialValue || '')
+
   useEffect(() => {
-    putInputValue(actionId, initialValue || '')
+    const nextValue = initialValue || ''
+    putInputValue(actionId, nextValue)
+    setValue(nextValue)
     return () => deleteInputValue(actionId)
   }, [initialValue])
 
   const onChange = useCallback(
-    (_e: FormEvent<HTMLDivElement>, { value }: RadioGroupOnChangeData) => {
-      putInputValue(actionId, value)
+    (
+      _e: FormEvent<HTMLDivElement>,
+      { value: elementValue }: RadioGroupOnChangeData
+    ) => {
+      const nextValue = elementValue || ''
+      setValue(nextValue)
+      putInputValue(actionId, nextValue)
       const actionPayload = makePayload<SingleValueInputActionPayload>(
         {
           actionId,
           type: 'change' as 'change',
-          value,
+          value: nextValue,
         },
         metadata,
         include
@@ -70,8 +79,8 @@ export const RadioGroup = ({
     <FluentRadioGroup
       {...{
         id: actionId,
-        defaultValue: initialValue,
         onChange,
+        ...(value && { value }),
         ...(disambiguatingLabel
           ? { 'aria-label': disambiguatingLabel }
           : { 'aria-labelledby': contextualLabelId }),

--- a/packages/react/src/inputs/ShortTextInput/ShortTextInput.tsx
+++ b/packages/react/src/inputs/ShortTextInput/ShortTextInput.tsx
@@ -91,7 +91,9 @@ export const ShortTextInput = ({
   const { onAction: contextOnAction } = useFluentBlocksContext()
 
   useEffect(() => {
-    putInputValue(actionId, initialValue || '')
+    const nextValue = initialValue || ''
+    putInputValue(actionId, nextValue)
+    setValue(nextValue)
     return () => deleteInputValue(actionId)
   }, [initialValue])
 

--- a/packages/react/src/surfaces/Sidebar/Sidebar.stories.mdx
+++ b/packages/react/src/surfaces/Sidebar/Sidebar.stories.mdx
@@ -60,7 +60,7 @@ narrow to display the Sidebar next to the Main content.
       accentScheme: 'teams',
       sidebar: {
         title: fakeTitle(fake),
-        defaultActiveItem: `sidebar-action__0-0`,
+        initialActiveItem: `sidebar-action__0-0`,
         accordion: range(3).map((i) => ({
           actionId: `sidebar-item__${i}`,
           label: fakeTitle(fake),

--- a/packages/react/src/surfaces/Sidebar/Sidebar.tsx
+++ b/packages/react/src/surfaces/Sidebar/Sidebar.tsx
@@ -58,7 +58,7 @@ export interface AccordionSidebarProps
     AccordionProps {}
 export interface FlatSidebarProps extends SidebarCommonProps {
   menu: MenuItemSequence
-  defaultActiveItem?: string
+  initialActiveItem?: string
 }
 
 export type SidebarProps = AccordionSidebarProps | FlatSidebarProps
@@ -136,7 +136,7 @@ export const Sidebar = (props: SidebarProps) => {
     cornerActions,
     deepCornerActionsMenuVariant = 'initial',
     contextualViewState,
-    defaultActiveItem,
+    initialActiveItem,
     onAction,
   } = props
   const sidebarStyles = useSidebarStyles()
@@ -148,12 +148,12 @@ export const Sidebar = (props: SidebarProps) => {
   } = useFluentBlocksContext()
   const labelId = key(title)
   const [activeItem, setActiveItem] = useState<string | null>(
-    defaultActiveItem || null
+    initialActiveItem || null
   )
 
   useEffect(() => {
-    setActiveItem(defaultActiveItem || null)
-  }, [defaultActiveItem])
+    setActiveItem(initialActiveItem || null)
+  }, [initialActiveItem])
 
   const onSidebarItemClick: SelectTabEventHandler = useCallback((event) => {
     const nextActiveItem = get(event, ['currentTarget', 'id'], null)

--- a/packages/react/src/surfaces/Topbar/Topbar.stories.mdx
+++ b/packages/react/src/surfaces/Topbar/Topbar.stories.mdx
@@ -129,7 +129,7 @@ will also add notifications to the far side of the Topbar.
             icon: 'grid',
           },
         ],
-        defaultActiveItem: 'sidebar-action__0',
+        initialActiveItem: 'sidebar-action__0',
         menu: range(6).map((s) => ({
           action: {
             actionId: `sidebar-action__${s}`,

--- a/packages/schemas/types/lib/accordion.d.ts
+++ b/packages/schemas/types/lib/accordion.d.ts
@@ -5,7 +5,7 @@ export interface AccordionItemProps {
   actionId: string
   label: InlineSequenceOrString
   menu: MenuItemSequence
-  defaultActiveItem?: string
+  initialActiveItem?: string
 }
 
 export interface AccordionProps {

--- a/packages/schemas/types/surfaces/Sidebar.d.ts
+++ b/packages/schemas/types/surfaces/Sidebar.d.ts
@@ -4,13 +4,13 @@ import { MenuActionSequence, MenuItemSequence } from '../lib/menu'
 
 export interface SidebarCommonProps {
   title: InlineSequenceOrString
-  defaultActiveItem?: string
+  initialActiveItem?: string
   cornerActions?: MenuActionSequence
   deepCornerActionsMenuVariant?: 'initial' | 'middle'
 }
 
 interface SidebarAccordionProps extends Omit<AccordionProps, 'accordion'> {
-  accordion: Omit<AccordionItemProps, 'defaultActiveItem'>[]
+  accordion: Omit<AccordionItemProps, 'initialActiveItem'>[]
 }
 
 export interface AccordionSidebarProps


### PR DESCRIPTION
This PR allows developers to programmatically change any input’s state using `initialValue`, which is handled as an effect and still propagates to the shared input store.