### PR TITLE
Fix input state

### DIFF
--- a/.changeset/hip-camels-learn.md
+++ b/.changeset/hip-camels-learn.md
@@ -1,0 +1,5 @@
+---
+'@fluent-blocks/react': patch
+---
+
+Inputs no longer set internal state on changes in the initialValue(s) prop.

--- a/packages/react/src/inputs/Select/variants/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/inputs/Select/variants/CheckboxGroup/CheckboxGroup.tsx
@@ -44,9 +44,8 @@ export const CheckboxGroup = ({
 
   useEffect(() => {
     putInputValue(actionId, initialValues || [])
-    setValues(new Set(initialValues))
     return () => deleteInputValue(actionId)
-  }, [initialValues])
+  }, [])
 
   const onChange = useCallback(
     (

--- a/packages/react/src/inputs/Select/variants/Dropdown/Dropdown.tsx
+++ b/packages/react/src/inputs/Select/variants/Dropdown/Dropdown.tsx
@@ -57,11 +57,9 @@ export const Dropdown = ({
   const [value, setValue] = useState<string>(initialValue || '')
 
   useEffect(() => {
-    const nextValue = initialValue || ''
-    putInputValue(actionId, nextValue)
-    setValue(nextValue)
+    putInputValue(actionId, initialValue || '')
     return () => deleteInputValue(actionId)
-  }, [initialValue])
+  }, [])
 
   const onChange = useCallback(
     ({ target }: ChangeEvent<HTMLSelectElement>) => {

--- a/packages/react/src/inputs/Select/variants/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/inputs/Select/variants/RadioGroup/RadioGroup.tsx
@@ -46,11 +46,9 @@ export const RadioGroup = ({
   const [value, setValue] = useState<string>(initialValue || '')
 
   useEffect(() => {
-    const nextValue = initialValue || ''
-    putInputValue(actionId, nextValue)
-    setValue(nextValue)
+    putInputValue(actionId, initialValue || '')
     return () => deleteInputValue(actionId)
-  }, [initialValue])
+  }, [])
 
   const onChange = useCallback(
     (

--- a/packages/react/src/inputs/ShortTextInput/ShortTextInput.tsx
+++ b/packages/react/src/inputs/ShortTextInput/ShortTextInput.tsx
@@ -91,11 +91,9 @@ export const ShortTextInput = ({
   const { onAction: contextOnAction } = useFluentBlocksContext()
 
   useEffect(() => {
-    const nextValue = initialValue || ''
-    putInputValue(actionId, nextValue)
-    setValue(nextValue)
+    putInputValue(actionId, initialValue || '')
     return () => deleteInputValue(actionId)
-  }, [initialValue])
+  }, [])
 
   useEffect(() => {
     putInputValue(actionId, debouncedValue)


### PR DESCRIPTION
This PR rolls back changes to inputs that set internal state based on changes in the `initialValue`(s) prop.