### PR TITLE
Select-multiple addable options

### DIFF
--- a/.changeset/quiet-taxis-hide.md
+++ b/.changeset/quiet-taxis-hide.md
@@ -1,0 +1,6 @@
+---
+'@fluent-blocks/react': minor
+'@fluent-blocks/schemas': minor
+---
+
+Add 'addable' to option props, which instructs multiple Selects which other options are added automatically when another option is added.

--- a/packages/react/src/inputs/Select/variants/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/inputs/Select/variants/CheckboxGroup/CheckboxGroup.tsx
@@ -1,4 +1,12 @@
-import { ChangeEvent, Fragment, useCallback, useEffect, useState } from 'react'
+import get from 'lodash/get'
+import {
+  ChangeEvent,
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 
 import { MultipleValueInputActionPayload } from '@fluent-blocks/schemas'
 import { Checkbox, CheckboxOnChangeData } from '@fluentui/react-components'
@@ -12,7 +20,10 @@ import {
   putInputValue,
   useFluentBlocksContext,
 } from '../../../../lib'
-import { MultipleSelectProps } from '../../../../props'
+import {
+  AddableLabeledValueProps,
+  MultipleSelectProps,
+} from '../../../../props'
 
 export interface CheckboxGroupProps
   extends Omit<MultipleSelectProps, 'select'> {
@@ -40,7 +51,32 @@ export const CheckboxGroup = ({
 }: CheckboxGroupProps) => {
   const { onAction: contextOnAction } = useFluentBlocksContext()
 
+  const valueMap = useMemo(
+    () =>
+      options.reduce(
+        (acc: Record<string, AddableLabeledValueProps>, option) => {
+          acc[option.value] = option
+          return acc
+        },
+        {}
+      ),
+    [options]
+  )
+
   const [values, setValues] = useState<Set<string>>(new Set(initialValues))
+
+  const disabledValueMap = useMemo(
+    () =>
+      options.reduce((acc: Record<string, boolean>, option) => {
+        get(option, 'adds', []).forEach((addedValue: string) => {
+          if (values.has(option.value)) {
+            acc[addedValue] = true
+          }
+        })
+        return acc
+      }, {}),
+    [values, options]
+  )
 
   useEffect(() => {
     putInputValue(actionId, initialValues || [])
@@ -54,6 +90,9 @@ export const CheckboxGroup = ({
     ) => {
       if (checked) {
         values.add(value)
+        get(valueMap, [value, 'adds'], []).forEach((addedValue) =>
+          values.add(addedValue)
+        )
       } else {
         values.delete(value)
       }
@@ -99,6 +138,7 @@ export const CheckboxGroup = ({
                 ...(description && {
                   'aria-describedby': optionDescriptionId,
                 }),
+                ...(disabledValueMap[value] && { disabled: true }),
               }}
             />
             {description && (

--- a/packages/react/src/inputs/Select/variants/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/inputs/Select/variants/CheckboxGroup/CheckboxGroup.tsx
@@ -93,6 +93,9 @@ export const CheckboxGroup = ({
         get(valueMap, [value, 'adds'], []).forEach((addedValue) =>
           values.add(addedValue)
         )
+        get(valueMap, [value, 'addsForConvenience'], []).forEach((addedValue) =>
+          values.add(addedValue)
+        )
       } else {
         values.delete(value)
       }

--- a/packages/react/src/props/inputs.ts
+++ b/packages/react/src/props/inputs.ts
@@ -42,6 +42,7 @@ export interface DescribedLabeledValueProps
 export interface AddableLabeledValueProps
   extends WithDescribedInputElements<NaturalDescribedLabeledValueProps> {
   adds?: string[]
+  addsForConvenience?: string[]
 }
 
 export type ShortInputContextualVariant =

--- a/packages/react/src/props/inputs.ts
+++ b/packages/react/src/props/inputs.ts
@@ -39,6 +39,11 @@ export interface LabeledValueProps
 export interface DescribedLabeledValueProps
   extends WithDescribedInputElements<NaturalDescribedLabeledValueProps> {}
 
+export interface AddableLabeledValueProps
+  extends WithDescribedInputElements<NaturalDescribedLabeledValueProps> {
+  adds?: string[]
+}
+
 export type ShortInputContextualVariant =
   | 'block-inputs'
   | 'card-inputs'

--- a/packages/react/src/props/select.ts
+++ b/packages/react/src/props/select.ts
@@ -8,6 +8,7 @@ import {
 
 import { WithActionHandler } from './actions'
 import {
+  AddableLabeledValueProps,
   DescribedLabeledValueProps,
   WithDescribedInputElements,
 } from './inputs'
@@ -30,9 +31,9 @@ export interface MultipleSelectInnerProps
     >,
     WithActionHandler<MultipleValueInputActionPayload> {
   options: [
-    DescribedLabeledValueProps,
-    DescribedLabeledValueProps,
-    ...DescribedLabeledValueProps[]
+    AddableLabeledValueProps,
+    AddableLabeledValueProps,
+    ...AddableLabeledValueProps[]
   ]
 }
 

--- a/packages/react/src/views/View/View.stories.mdx
+++ b/packages/react/src/views/View/View.stories.mdx
@@ -273,7 +273,7 @@ that time `View` will call its interaction callback with the update.
                       label: [{ text: fakeTitle(fake) }],
                       value: 'u2',
                       description: fake('{{lorem.sentence}}'),
-                      adds: ['u3', 'u4'],
+                      addsForConvenience: ['u3', 'u4'],
                     },
                     {
                       label: [{ text: fakeTitle(fake) }],

--- a/packages/react/src/views/View/View.stories.mdx
+++ b/packages/react/src/views/View/View.stories.mdx
@@ -273,6 +273,17 @@ that time `View` will call its interaction callback with the update.
                       label: [{ text: fakeTitle(fake) }],
                       value: 'u2',
                       description: fake('{{lorem.sentence}}'),
+                      adds: ['u3', 'u4'],
+                    },
+                    {
+                      label: [{ text: fakeTitle(fake) }],
+                      value: 'u3',
+                      description: fake('{{lorem.sentence}}'),
+                    },
+                    {
+                      label: [{ text: fakeTitle(fake) }],
+                      value: 'u4',
+                      description: fake('{{lorem.sentence}}'),
                     },
                   ],
                 },

--- a/packages/schemas/types/inputs/Select.d.ts
+++ b/packages/schemas/types/inputs/Select.d.ts
@@ -1,7 +1,7 @@
 import {
+  AddableLabeledValueProps,
   DescribedInputProps,
   DescribedLabeledValueProps,
-  IncludableLabeledValueProps,
   InputInitialValueProps,
   InputInitialValuesProps,
   InputRequiredProps,
@@ -29,9 +29,9 @@ export interface MultipleSelectInnerProps
   variant: SelectVariant
   multiple: true
   options: [
-    IncludableLabeledValueProps,
-    IncludableLabeledValueProps,
-    ...IncludableLabeledValueProps[]
+    AddableLabeledValueProps,
+    AddableLabeledValueProps,
+    ...AddableLabeledValueProps[]
   ]
 }
 

--- a/packages/schemas/types/inputs/Select.d.ts
+++ b/packages/schemas/types/inputs/Select.d.ts
@@ -1,6 +1,7 @@
 import {
   DescribedInputProps,
   DescribedLabeledValueProps,
+  IncludableLabeledValueProps,
   InputInitialValueProps,
   InputInitialValuesProps,
   InputRequiredProps,
@@ -28,9 +29,9 @@ export interface MultipleSelectInnerProps
   variant: SelectVariant
   multiple: true
   options: [
-    DescribedLabeledValueProps,
-    DescribedLabeledValueProps,
-    ...DescribedLabeledValueProps[]
+    IncludableLabeledValueProps,
+    IncludableLabeledValueProps,
+    ...IncludableLabeledValueProps[]
   ]
 }
 

--- a/packages/schemas/types/inputs/input-properties.d.ts
+++ b/packages/schemas/types/inputs/input-properties.d.ts
@@ -56,8 +56,8 @@ export interface DescribedLabeledValueProps
   extends LabeledValueProps,
     DescriptionProps {}
 
-export interface IncludableLabeledValueProps
+export interface AddableLabeledValueProps
   extends LabeledValueProps,
     DescriptionProps {
-  includes?: string[]
+  adds?: string[]
 }

--- a/packages/schemas/types/inputs/input-properties.d.ts
+++ b/packages/schemas/types/inputs/input-properties.d.ts
@@ -55,3 +55,9 @@ export interface LabeledValueProps {
 export interface DescribedLabeledValueProps
   extends LabeledValueProps,
     DescriptionProps {}
+
+export interface IncludableLabeledValueProps
+  extends LabeledValueProps,
+    DescriptionProps {
+  includes?: string[]
+}

--- a/packages/schemas/types/inputs/input-properties.d.ts
+++ b/packages/schemas/types/inputs/input-properties.d.ts
@@ -60,4 +60,5 @@ export interface AddableLabeledValueProps
   extends LabeledValueProps,
     DescriptionProps {
   adds?: string[]
+  addsForConvenience?: string[]
 }


### PR DESCRIPTION
This PR lets developers specify whether options in a multiple-variant Select can automatically add other options in the same Select.

Using `adds` (disables added options):

![Screen Recording 2022-07-08 at 12 29 45 mov](https://user-images.githubusercontent.com/855039/178059613-440d0e24-afd6-44ef-8f60-ab98e68c1423.gif)

Using `addsForConvenience` (does not disable added options):

![Screen Recording 2022-07-08 at 12 51 52 mov](https://user-images.githubusercontent.com/855039/178061278-ddfda3da-a782-4253-9d7e-7a4ce47727f9.gif)

