### PR TITLE
Text variants

### DIFF
--- a/.changeset/six-mice-listen.md
+++ b/.changeset/six-mice-listen.md
@@ -1,0 +1,6 @@
+---
+'@fluent-blocks/react': minor
+'@fluent-blocks/schemas': minor
+---
+
+Adds support for Text variants, and uses the subtle variant for input descriptions.

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -24,6 +24,7 @@ export const parameters = {
         'Views',
         'Surfaces',
         'Blocks',
+        'Inputs',
         'Media',
         '*',
       ],

--- a/packages/react/src/blocks/Card/Card.tsx
+++ b/packages/react/src/blocks/Card/Card.tsx
@@ -63,6 +63,7 @@ const useCardStyles = makeStyles({
   headingRow: {
     display: 'flex',
     paddingBlockStart: rem(8),
+    paddingBlockEnd: 0,
   },
   headingText: {
     ...sx.flex(1, 1, 'auto'),
@@ -71,6 +72,7 @@ const useCardStyles = makeStyles({
   cardContentSpacing: {
     paddingInlineStart: rem(16),
     paddingInlineEnd: rem(16),
+    paddingBlockEnd: rem(8),
   },
 })
 

--- a/packages/react/src/blocks/Paragraph/Paragraph.tsx
+++ b/packages/react/src/blocks/Paragraph/Paragraph.tsx
@@ -37,7 +37,8 @@ export const Paragraph = (props: ParagraphProps) => {
         contextualVariant === 'inputMeta' && textBlockStyles.inputMetaSpacing,
         contextualVariant === 'inputMeta--selectOption' &&
           textBlockStyles.selectOptionMetaSpacing,
-        contextualVariant === 'inputMeta' && textStyles.inputMeta,
+        contextualVariant === 'inputMeta' && textStyles.subtle,
+        contextualVariant === 'inputMeta--selectOption' && textStyles.subtle,
         visuallyHidden && commonStyles.visuallyHidden
       )}
       {...(contextualId && { id: contextualId })}

--- a/packages/react/src/inlines/Text/Text.stories.mdx
+++ b/packages/react/src/inlines/Text/Text.stories.mdx
@@ -61,14 +61,6 @@ Each of these variants is demonstrated here, preceded by the specific `variant` 
                 },
               ],
             },
-            {
-              paragraph: [
-                {
-                  text: fake('‘stronger’ — {{lorem.sentence}} '),
-                  variant: 'stronger',
-                },
-              ],
-            },
           ],
         }
       }

--- a/packages/react/src/inlines/Text/Text.stories.mdx
+++ b/packages/react/src/inlines/Text/Text.stories.mdx
@@ -1,0 +1,77 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs'
+
+import { fake, seed } from '../../lib/fake'
+import { View } from '../../views'
+
+<Meta
+  title="Facets/Type styles"
+  component={View}
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+/>
+
+# Type styles
+
+Fluent and the UI Kit specify some type styles which content authors can use freely in some contexts and which in other contexts are applied automatically.
+
+- [Fluent › Text](https://www.figma.com/file/IkBEp9pnO4Ep7HH4Bq5xrW/Text?node-id=2%3A895)
+
+Each of these variants is demonstrated here, preceded by the specific `variant` value you can use in typical instances of `<Text text={"…"} variant={…}/>`/`{text: "…", variant: "…"}`.
+
+<Canvas withSource="none">
+  <Story name="Type styles">
+    <View
+      main={
+        seed(1234) || {
+          title: '',
+          blocks: [
+            {
+              paragraph: [{ text: fake('Default text — {{lorem.sentence}} ') }],
+            },
+            {
+              paragraph: [
+                {
+                  text: fake('‘emphasized’ — {{lorem.sentence}} '),
+                  variant: 'emphasized',
+                },
+              ],
+            },
+            {
+              paragraph: [
+                { text: fake('‘code’ — {{lorem.sentence}} '), variant: 'code' },
+              ],
+            },
+            {
+              paragraph: [
+                {
+                  text: fake('‘subtle’ — {{lorem.sentence}} '),
+                  variant: 'subtle',
+                },
+              ],
+            },
+            {
+              paragraph: [
+                {
+                  text: fake('‘strong’ — {{lorem.sentence}} '),
+                  variant: 'strong',
+                },
+              ],
+            },
+            {
+              paragraph: [
+                {
+                  text: fake('‘stronger’ — {{lorem.sentence}} '),
+                  variant: 'stronger',
+                },
+              ],
+            },
+          ],
+        }
+      }
+    />
+  </Story>
+</Canvas>

--- a/packages/react/src/inlines/Text/Text.tsx
+++ b/packages/react/src/inlines/Text/Text.tsx
@@ -11,7 +11,11 @@ export const Text = (props: TextProps) => {
   const textStyles = useTextStyles()
   switch (variant) {
     case 'code':
-      return <code className={textStyles.code}>{text}</code>
+      return <code className={textStyles[variant]}>{text}</code>
+    case 'strong':
+    case 'emphasized':
+    case 'subtle':
+      return <span className={textStyles[variant]}>{text}</span>
     default:
       return <>{text}</>
   }

--- a/packages/react/src/inputs/Select/Select.stories.mdx
+++ b/packages/react/src/inputs/Select/Select.stories.mdx
@@ -1,0 +1,196 @@
+import range from 'lodash/range'
+
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs'
+
+import { contextArgTypes } from '../../lib'
+import { fake, fakeTitle, seed } from '../../lib/fake'
+import iconSpriteUrl from '../../lib/storybookIconSpriteUrl'
+import { View } from '../../views'
+import { Select } from './Select'
+
+<Meta
+  title="Inputs/Select (radio buttons, checkboxes, dropdowns, and comboboxes)"
+  component={Select}
+  argTypes={{
+    ...contextArgTypes,
+  }}
+/>
+
+export const SelectTemplate = ({ themeName, accentScheme, ...props }) => (
+  <View
+    {...{
+      themeName,
+      accentScheme,
+      iconSpriteUrl,
+      main: {
+        title: '',
+        blocks: [{ select: props.select }],
+      },
+    }}
+  />
+)
+
+# Select
+
+Fluent Blocks organizes several design patterns with closely related underlying
+ontologies: radio button groups, groups of checkboxes, dropdown menus, and
+multiple-select “combobox” menus, into a single component, ‘Select’.
+
+## Radio buttons (`variant: 'group', multiple: false`)
+
+<Canvas withSource="none">
+  <Story
+    name="Radio buttons"
+    args={{
+      themeName: 'light',
+      accentScheme: 'teams',
+      select: {
+        variant: 'group',
+        actionId: 's1',
+        label: 'Radio group',
+        description:
+          'Using a group-variant Select without the multiple flag will render a radio group',
+        options: range(5).map((r) => ({
+          label: [{ text: fakeTitle(fake) }],
+          value: `s1__o${r}`,
+          description: fake('{{lorem.sentence}}'),
+        })),
+      },
+    }}
+  >
+    {seed(1234) || SelectTemplate.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Radio buttons" />
+
+## Checkboxes (`variant: 'group', multiple: true`)
+
+<Canvas withSource="none">
+  <Story
+    name="Checkboxes"
+    args={{
+      themeName: 'light',
+      accentScheme: 'teams',
+      select: {
+        variant: 'group',
+        multiple: true,
+        actionId: 's2',
+        label: 'Checkboxes',
+        description:
+          'Using a group-variant Select with the multiple flag will render a group of checkboxes',
+        options: range(5).map((r) => ({
+          label: [{ text: fakeTitle(fake) }],
+          value: `s2__o${r}`,
+          description: fake('{{lorem.sentence}}'),
+        })),
+      },
+    }}
+  >
+    {seed(1234) || SelectTemplate.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Checkboxes" />
+
+Checkboxes permit special properties on their `options` that will automatically
+add sibling options when they’re checked, either in a mandatory way with the
+`adds` prop, or for convenience with the `addsForConvenience` prop.
+
+<Canvas withSource="none">
+  <Story
+    name="Checkboxes with automatic selection"
+    args={{
+      themeName: 'light',
+      accentScheme: 'teams',
+      select: {
+        variant: 'group',
+        multiple: true,
+        actionId: 's3',
+        label: 'Checkboxes with automatic selection',
+        description: [
+          { text: 'Using ' },
+          { text: 'adds', variant: 'code' },
+          { text: ' or ' },
+          { text: 'addsForConvenience', variant: 'code' },
+          { text: ' will automatically select sibling options.' },
+        ],
+        options: range(5).map((r) => ({
+          label:
+            r === 1
+              ? 'Selecting this option will add others'
+              : [{ text: fakeTitle(fake) }],
+          value: `s3__o${r}`,
+          description: fake('{{lorem.sentence}}'),
+          ...(r === 1 && {
+            adds: [`s3__o${r + 1}`],
+            addsForConvenience: [`s3__o${r + 2}`],
+          }),
+        })),
+      },
+    }}
+  >
+    {seed(1234) || SelectTemplate.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Checkboxes with automatic selection" />
+
+## Dropdown (`variant: 'combobox', multiple: false`)
+
+<Canvas withSource="none">
+  <Story
+    name="Dropdown"
+    args={{
+      themeName: 'light',
+      accentScheme: 'teams',
+      select: {
+        variant: 'combobox',
+        actionId: 's4',
+        label: 'Dropdown',
+        description:
+          'Using a combobox-variant Select without the multiple flag will render a Dropdown',
+        placeholder: 'Select a value',
+        options: range(5).map((r) => ({
+          label: fakeTitle(fake),
+          value: `s4__o${r}`,
+          description: fake('{{lorem.sentence}}'),
+        })),
+      },
+    }}
+  >
+    {seed(1234) || SelectTemplate.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Dropdown" />
+
+## Combobox (`variant: 'combobox', multiple: true`)
+
+<Canvas withSource="none">
+  <Story
+    name="Combobox"
+    args={{
+      themeName: 'light',
+      accentScheme: 'teams',
+      select: {
+        variant: 'combobox',
+        multiple: true,
+        actionId: 's5',
+        label: 'Combobox',
+        description:
+          'Using a combobox-variant Select with the multiple flag will render a Combobox',
+        placeholder: 'Select some values',
+        options: range(5).map((r) => ({
+          label: fakeTitle(fake),
+          value: `s5__o${r}`,
+          description: fake('{{lorem.sentence}}'),
+        })),
+      },
+    }}
+  >
+    {seed(1234) || SelectTemplate.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Combobox" />

--- a/packages/react/src/lib/Intro.stories.mdx
+++ b/packages/react/src/lib/Intro.stories.mdx
@@ -44,18 +44,28 @@ When you use Fluent Blocks, you aren’t locked into its way of doing things —
 
 Fluent Blocks is essentially a React implementation of many [Fluent][figma-fluent] & [UI Kit][figma-uikit] design patterns for app development based on [`@fluentui/react-components`][fluentui-v9]. This project succeeds [`@fluentui/react-teams`][react-teams].
 
-## ⚠️ In active development
+## ⚠️ Not yet recommended for production
 
-This project’s API is subject to unannounced breaking changes and is not yet on any release cycle.
+This project is still being vetted. If you want to use Fluent Blocks, please bear in mind even non-prereleases don’t yet come with any particular guarantees.
+
+For the best experience specify a specific version of Fluent Blocks when installing instead of using `~`/`^`/`*`, tags, or ranges. If you encounter issues or when you want to use new features, migrate to a newer version with care.
 
 ## Getting started
 
 Using TypeScript and an IDE that supports type inspections will make using this project much easier!
 
-1. Add `react@17`, `react-dom@17`, and `@fluentui/react-components@latest` if they’re not in your project already
-2. Add `chart.js@^2.9.4` if you want to use charts from this package
-3. Depending on your package manager, you may need to add `@fluent-blocks/basic-icons` to use icons
-4. Finally, install this package, `@fluent-blocks/react`, using your package manager
+1. Add `react@17`, `react-dom@17` if they’re not in your project already
+
+- Versions of React from `^16.14.0` up to `18` are supported, in case your project already uses a version in that range
+
+3. Depending on your bundler you may need to add `chart.js@^2.9.4`, which you’ll need anyway if you want to use charts from this package
+4. Install this package and the icons sprite **with `--save-exact`** using your package manager:
+
+- NPM: `npm install --save --save-exact @fluent-blocks/react @fluent-blocks/basic-icons`
+- Yarn: `yarn add --exact @fluent-blocks/react @fluent-blocks/basic-icons`
+- PNPM: `pnpm add --save-exact @fluent-blocks/react @fluent-blocks/basic-icons`
+
+Fluent Blocks comes with `@fluentui/react-components@~9.0.1` as a dependency — if you anticipate wanting to use components from that library in your project alongside Fluent Blocks, you should also add it as a direct dependency.
 
 Now anywhere you can use React, you can use Fluent Blocks.
 
@@ -158,10 +168,14 @@ The components listed in the sidebar are available in Fluent Blocks as of the ve
 
 ## Technical info, contributing, and getting help.
 
+If you encounter issues, have questions, or want to participate, please don’t hesitate to [write an issue on Github][issues]. You can also [join us on Teams in our community channel][channel].
+
+If you’d like to run the development environment or contribute to this project, please see [the Contributing file](CONTRIBUTING.md).
+
 If you’d like more technical information about Fluent Blocks or if you want to look into contributing, please have a look at the project’s [Github repository][github-readme].
 
-If you have a question, found a bug, or want to request a feature, we’d love to hear from you on the project’s [Github issues][github-issues].
-
+[channel]: https://teams.microsoft.com/l/team/19%3atKKC3lewTMtk4IopGy7Seq7fok-lNW7lGEK-HmzfaKY1%40thread.tacv2/conversations?groupId=4f925ae9-c713-434b-a1f6-44b58ac57210&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47
+[issues]: https://github.com/OfficeDev/fluent-blocks/issues
 [figma-fluent]: https://www.figma.com/community/file/836828295772957889/Microsoft-Fluent-Web
 [figma-uikit]: https://www.figma.com/community/file/916836509871353159/Microsoft-Teams-UI-Kit
 [fluentui-v9]: https://www.npmjs.com/package/@fluentui/react-components

--- a/packages/react/src/lib/Provider/FluentBlocksProvider.stories.mdx
+++ b/packages/react/src/lib/Provider/FluentBlocksProvider.stories.mdx
@@ -4,7 +4,7 @@ import { seed } from '../fake'
 import { StorybookColorProvider } from './StorybookColorProvider'
 
 <Meta
-  title="Facets/Color"
+  title="Facets/Procedural color"
   component={StorybookColorProvider}
   argTypes={{
     keyColor: {
@@ -52,7 +52,7 @@ import { StorybookColorProvider } from './StorybookColorProvider'
 
 export const ColorTemplate = (props) => <StorybookColorProvider {...props} />
 
-# Color
+# Procedural color
 
 Fluent Blocks allows you to specify an accent color palette that **may be
 accessible\*** with very little effort on your part. In the
@@ -72,7 +72,7 @@ components you use, in both light and dark themes.
 
 <Canvas withSource="none">
   <Story
-    name="Color"
+    name="Procedural color"
     args={{
       keyColor: '#e38651',
       lightCp: 0.8,
@@ -85,4 +85,4 @@ components you use, in both light and dark themes.
   </Story>
 </Canvas>
 
-<ArgsTable story="Color" />
+<ArgsTable story="Procedural color" />

--- a/packages/react/src/lib/commonStyles.ts
+++ b/packages/react/src/lib/commonStyles.ts
@@ -107,6 +107,19 @@ export const useTextStyles = makeStyles({
     textDecorationStyle: 'dotted',
   },
   inputMeta: {},
+  strong: {
+    fontWeight: 600,
+  },
+  stronger: {
+    fontWeight: 700,
+  },
+  emphasized: {
+    fontStyle: 'italic',
+  },
+  subtle: {
+    color: 'var(--colorNeutralForeground3)',
+    fontSize: 'var(--fontSizeBase200)',
+  },
 })
 
 export const useShortInputStyles = makeStyles({

--- a/packages/react/src/lib/commonStyles.ts
+++ b/packages/react/src/lib/commonStyles.ts
@@ -106,7 +106,6 @@ export const useTextStyles = makeStyles({
     textDecorationLine: 'underline',
     textDecorationStyle: 'dotted',
   },
-  inputMeta: {},
   strong: {
     fontWeight: 'var(--fontWeightSemibold)',
   },

--- a/packages/react/src/lib/commonStyles.ts
+++ b/packages/react/src/lib/commonStyles.ts
@@ -108,10 +108,7 @@ export const useTextStyles = makeStyles({
   },
   inputMeta: {},
   strong: {
-    fontWeight: 600,
-  },
-  stronger: {
-    fontWeight: 700,
+    fontWeight: 'var(--fontWeightSemibold)',
   },
   emphasized: {
     fontStyle: 'italic',

--- a/packages/schemas/types/inlines/Text.d.ts
+++ b/packages/schemas/types/inlines/Text.d.ts
@@ -1,10 +1,4 @@
-export type TextVariant =
-  | 'normal'
-  | 'emphasized'
-  | 'strong'
-  | 'stronger'
-  | 'subtle'
-  | 'code'
+export type TextVariant = 'normal' | 'emphasized' | 'strong' | 'subtle' | 'code'
 
 export interface TextProps {
   text: string

--- a/packages/schemas/types/inlines/Text.d.ts
+++ b/packages/schemas/types/inlines/Text.d.ts
@@ -2,7 +2,8 @@ export type TextVariant =
   | 'normal'
   | 'emphasized'
   | 'strong'
-  | 'highlighted'
+  | 'stronger'
+  | 'subtle'
   | 'code'
 
 export interface TextProps {


### PR DESCRIPTION
This PR adds support for Text variants, and uses the `subtle` variant for input descriptions.

<img width="456" alt="Screen Shot 2022-07-08 at 18 21 29" src="https://user-images.githubusercontent.com/855039/178086370-0b7bf916-f9eb-4449-9212-90f590d34e6b.png">
<img width="480" alt="Screen Shot 2022-07-08 at 18 21 51" src="https://user-images.githubusercontent.com/855039/178086371-745d7c30-d4f7-43d1-967e-9882ed92fcb5.png">

This PR also:
- Harmonizes the Introduction story with this repo’s readme
- Adds stories for Select
- Fixes a visual issue in Cards
- Renames and rearranges some stories