### PR TITLE
Loading as media variant, icon, and special state for Table and List

### DIFF
--- a/.changeset/blue-shoes-press.md
+++ b/.changeset/blue-shoes-press.md
@@ -1,0 +1,6 @@
+---
+'@fluent-blocks/react': minor
+'@fluent-blocks/schemas': minor
+---
+
+Add Loading as media variant, icon, and special state for Table and List.

--- a/packages/react/src/blocks/BigMessage/BigMessage.stories.mdx
+++ b/packages/react/src/blocks/BigMessage/BigMessage.stories.mdx
@@ -192,3 +192,24 @@ Error states come in many forms. Consider an appropriate illustration to ease th
 </Canvas>
 
 <ArgsTable story="Error without illustration" />
+
+<Canvas>
+  <Story
+    name="Loading"
+    args={{
+      themeName: 'light',
+      accentScheme: 'teams',
+      title: '',
+      media: {
+        loading: {
+          variant: 'spinner',
+        },
+        label: 'Loading',
+      },
+    }}
+  >
+    {BigMessageTemplate.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Loading" />

--- a/packages/react/src/blocks/List/List.tsx
+++ b/packages/react/src/blocks/List/List.tsx
@@ -186,12 +186,15 @@ export const List = ({ list, contextualVariant = 'block' }: ListProps) => {
         <Toolbar
           toolbar={{
             menu: [
-              ...(list.listActions || []).map((action) => ({ action })),
+              ...(list.listActions || []).map((action) => ({
+                action: { ...action, ...(list.loading && { disabled: true }) },
+              })),
               ...Object.keys(rowActions || []).map((actionId) => ({
                 action: {
                   ...rowActions![actionId],
                   actionId,
                   metadata: { rows: Array.from(selection) },
+                  ...(list.loading && { disabled: true }),
                 },
                 ...(!commonActions.has(actionId) && {
                   hidden: true,
@@ -213,6 +216,7 @@ export const List = ({ list, contextualVariant = 'block' }: ListProps) => {
                 setPage(0)
               }
             },
+            ...(list.loading && { disabled: true }),
           }}
         />
       )}
@@ -223,14 +227,16 @@ export const List = ({ list, contextualVariant = 'block' }: ListProps) => {
           contextualSelectionProps: { selection, setSelection },
         })}
       />
-      <Pagination
-        {...{
-          page,
-          setPage,
-          pageSize,
-          collectionSize: sortedRowKeys.length,
-        }}
-      />
+      {!list.loading && (
+        <Pagination
+          {...{
+            page,
+            setPage,
+            pageSize,
+            collectionSize: sortedRowKeys.length,
+          }}
+        />
+      )}
     </>
   )
 }

--- a/packages/react/src/blocks/Toolbar/Toolbar.tsx
+++ b/packages/react/src/blocks/Toolbar/Toolbar.tsx
@@ -34,6 +34,7 @@ export interface ToolbarProps extends Omit<NaturalToolbarProps, 'toolbar'> {
   contextualVariant?: 'block' | 'viewportWidth'
   contextualFindProps?: {
     onAction: (payload: SingleValueInputActionPayload) => void
+    disabled?: boolean
   }
   contextualJustifyEnd?: boolean
   contextualRole?: 'menubar' | 'group'
@@ -243,6 +244,9 @@ export const Toolbar = ({
                 after: { icon: 'document_search' },
                 ...(contextualFindProps?.onAction && {
                   onAction: (payload) => contextualFindProps.onAction(payload),
+                }),
+                ...(contextualFindProps?.disabled && {
+                  disabled: true,
                 }),
               },
               contextualVariant: 'toolbar-item',

--- a/packages/react/src/inlines/Icon/Icon.tsx
+++ b/packages/react/src/inlines/Icon/Icon.tsx
@@ -7,7 +7,7 @@ import {
   IconVariant,
   IconProps as NaturalIconProps,
 } from '@fluent-blocks/schemas'
-import { makeStyles } from '@fluentui/react-components'
+import { Spinner, makeStyles } from '@fluentui/react-components'
 
 import { useFluentBlocksContext } from '../../lib'
 
@@ -49,13 +49,23 @@ const useIconStyles = makeStyles({
     fill: 'currentcolor',
     flexShrink: 0,
   },
+  spinner: {
+    display: 'inline',
+  },
 })
 
 export const Icon = (props: IconProps) => {
   const { icon, variant = 'outline', size = 20 } = props
   const iconStyles = useIconStyles()
   const { iconSpriteUrl } = useFluentBlocksContext()
-  return (
+  return icon === 'loading' ? (
+    <Spinner
+      size="tiny"
+      appearance="inverted"
+      className={iconStyles.spinner}
+      data-chromatic="ignore"
+    />
+  ) : (
     <svg className={`${iconStyles.root} fuib-Icon`} data-chromatic="ignore">
       <use href={spriteHref(icon, size, variant, iconSpriteUrl)} />
     </svg>

--- a/packages/react/src/inlines/Icon/IconFinder.stories.mdx
+++ b/packages/react/src/inlines/Icon/IconFinder.stories.mdx
@@ -5,11 +5,12 @@ import { useEffect, useState } from 'react'
 
 import { Meta } from '@storybook/addon-docs'
 
-import { randomNumber, useDebounce } from '../../lib'
+import { FluentBlocksProvider, randomNumber, useDebounce } from '../../lib'
+import storybookIconSpriteUrl from '../../lib/storybookIconSpriteUrl'
 import { Icon } from './Icon'
 
 <Meta
-  title="Facets/Icons"
+  title="Facets/Icon finder"
   component={Icon}
   parameters={{
     viewMode: 'docs',
@@ -112,7 +113,7 @@ export const IconFinder = () => {
     ? icons.allIcons.filter((icon) => icon.includes(debouncedQuery))
     : []
   return (
-    <div>
+    <FluentBlocksProvider iconSpriteUrl={storybookIconSpriteUrl}>
       <section
         style={{
           display: 'grid',
@@ -228,11 +229,11 @@ export const IconFinder = () => {
           )}
         </>
       )}
-    </div>
+    </FluentBlocksProvider>
   )
 }
 
-# Icons
+# Icons from Fluent System Icons
 
 There are more than 1,750 icons in `react-system-icons` available for you to use
 with the `Icon` component, without having to list the repository containing the
@@ -242,8 +243,8 @@ Fluent Blocks brings `@fluent-blocks/basic-icons/basic-icons.svg` with it, which
 you should serve alongside your app. Provide `FluentBlocksProvider` with
 `iconSpriteUrl` pointing to where browsers can get `basic-icons.svg`.
 
-You can search for the icon you want to use here. Simply type a query in the
-input below and select the desired size. All icons are available in both
+You can search for all other icons you want to use here. Simply type a query in
+the input below and select the desired size. All icons are available in both
 ‘outline’ and ‘filled’ variants. Each result shows the icon at twice the
 display size, the name of the icon, and the sizes available with the display
 size in bold.
@@ -256,7 +257,8 @@ Do not use proxies for icons in production.
 
 ## Icon finder
 
-**These icons won’t appear on Chromatic. To see the icons on this page, run this
-project’s Storybook on your device locally.**
+**These icons won’t appear on Chromatic since proxies do not run there. To see
+icons not bundled with `basic-icons.svg` on this page, run this project’s
+Storybook on your device locally.**
 
 <IconFinder />

--- a/packages/react/src/inlines/Icon/Icons.stories.mdx
+++ b/packages/react/src/inlines/Icon/Icons.stories.mdx
@@ -1,0 +1,100 @@
+import { Canvas, Meta } from '@storybook/addon-docs'
+
+import { fake, seed } from '../../lib/fake'
+import storybookIconSpriteUrl from '../../lib/storybookIconSpriteUrl'
+import { View } from '../../views'
+import { Icon } from './Icon'
+
+<Meta
+  title="Facets/Icons"
+  component={Icon}
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+/>
+
+# Icons
+
+The `Icon` component rolls three modes into one:
+
+- If the specified icon is exactly `loading`, it will show a small
+  inline spinner.
+- If the specified icon is bundled in `basic-icons.svg`, it will serve the icon
+  from that asset
+- If the specified icon is not undled in `basic-icons.svg`, it will request the
+  icon from your app’s `/sprites` path
+
+## Loading
+
+<Canvas>
+  <Story name="Loading">
+    <View
+      iconSpriteUrl={storybookIconSpriteUrl}
+      main={
+        seed(1234) || {
+          title: '',
+          blocks: [
+            {
+              paragraph: [
+                { text: fake('{{lorem.sentence}} ') },
+                { icon: 'loading' },
+                { text: fake(' {{lorem.sentence}}') },
+              ],
+            },
+          ],
+        }
+      }
+    />
+  </Story>
+</Canvas>
+
+## Bundled
+
+<Canvas>
+  <Story name="Bundled">
+    <View
+      iconSpriteUrl={storybookIconSpriteUrl}
+      main={
+        seed(1234) || {
+          title: '',
+          blocks: [
+            {
+              paragraph: [
+                { text: fake('{{lorem.sentence}} ') },
+                { icon: 'globe' },
+                { text: fake(' {{lorem.sentence}}') },
+              ],
+            },
+          ],
+        }
+      }
+    />
+  </Story>
+</Canvas>
+
+## Fetched / proxied
+
+<Canvas>
+  <Story name="Fetched / proxied">
+    <View
+      iconSpriteUrl={storybookIconSpriteUrl}
+      main={
+        seed(1234) || {
+          title: '',
+          blocks: [
+            {
+              paragraph: [
+                { text: fake('{{lorem.sentence}} ') },
+                { icon: 'book_globe', size: 24 },
+                { text: fake(' {{lorem.sentence}}') },
+              ],
+            },
+          ],
+        }
+      }
+    />
+  </Story>
+</Canvas>

--- a/packages/react/src/inputs/ShortTextInput/ShortTextInput.tsx
+++ b/packages/react/src/inputs/ShortTextInput/ShortTextInput.tsx
@@ -72,6 +72,7 @@ export const ShortTextInput = ({
     onAction,
     metadata,
     include,
+    disabled,
   },
   contextualVariant = 'block-inputs',
   contextualElevationVariant = 'surface',
@@ -147,6 +148,7 @@ export const ShortTextInput = ({
         {...{
           id: actionId,
           placeholder,
+          disabled,
           value,
           onChange: ({ target }) => setValue(get(target, 'value', '')),
           type: inputType || 'text',

--- a/packages/react/src/lib/translations/en-US.ts
+++ b/packages/react/src/lib/translations/en-US.ts
@@ -23,4 +23,5 @@ export default {
   'link--targetBlank': 'Opens a new tab or window.',
   'link--externalTargetBlank':
     'Opens a new tab or window to an external website.',
+  loading: 'Loading',
 }

--- a/packages/react/src/media/Loading/Loading.tsx
+++ b/packages/react/src/media/Loading/Loading.tsx
@@ -1,0 +1,31 @@
+import { ReactElement } from 'react'
+
+import { LoadingProps as NaturalLoadingProps } from '@fluent-blocks/schemas'
+import { Spinner } from '@fluentui/react-components'
+
+export type LoadingProps = NaturalLoadingProps
+
+export const Loading = ({ loading, label }: LoadingProps) => (
+    <Spinner
+      size="huge"
+      labelPosition="below"
+      label={label}
+      data-chromatic="ignore"
+      aria-live="polite"
+    />
+  )
+
+export type LoadingElement = ReactElement<LoadingProps, typeof Loading>
+export type LoadingPropsOrElement = LoadingProps | LoadingElement
+
+function isLoadingProps(o: any): o is LoadingProps {
+  return 'loading' in o
+}
+
+function isLoadingElement(o: any): o is LoadingElement {
+  return o?.type === Loading
+}
+
+export function renderIfLoading(o: any) {
+  return isLoadingProps(o) ? <Loading {...o} /> : isLoadingElement(o) ? o : null
+}

--- a/packages/react/src/media/index.ts
+++ b/packages/react/src/media/index.ts
@@ -1,20 +1,22 @@
-import { EscapeElement, renderIfEscape, invalidMedia } from '../lib'
+import { EscapeElement, invalidMedia, renderIfEscape } from '../lib'
+import { ChartPropsOrElement, renderIfChart } from './Chart/Chart'
+import { CodePropsOrElement, renderIfCode } from './Code/Code'
 import {
   IllustrationPropsOrElement,
   renderIfIllustration,
 } from './Illustration/Illustration'
-import { CodePropsOrElement, renderIfCode } from './Code/Code'
+import { LoadingPropsOrElement, renderIfLoading } from './Loading/Loading'
 import {
-  renderIfThemedImage,
   ThemedImagePropsOrElement,
+  renderIfThemedImage,
 } from './ThemedImage/ThemedImage'
-import { ChartPropsOrElement, renderIfChart } from './Chart/Chart'
 
 export type MediaEntity =
   | IllustrationPropsOrElement
   | ChartPropsOrElement
   | CodePropsOrElement
   | ThemedImagePropsOrElement
+  | LoadingPropsOrElement
   | EscapeElement
 
 export const Media = (o: MediaEntity) =>
@@ -22,9 +24,11 @@ export const Media = (o: MediaEntity) =>
   renderIfChart(o) ||
   renderIfCode(o) ||
   renderIfThemedImage(o) ||
+  renderIfLoading(o) ||
   renderIfEscape(o) ||
   invalidMedia(o)
 
 export * from './Illustration/Illustration'
 export * from './Code/Code'
 export * from './ThemedImage/ThemedImage'
+export * from './Loading/Loading'

--- a/packages/schemas/types/inputs/ShortTextInput.d.ts
+++ b/packages/schemas/types/inputs/ShortTextInput.d.ts
@@ -20,6 +20,7 @@ export interface ShortTextInputInnerProps extends TextInputInnerProps {
   before?: InlineEntity
   after?: InlineEntity
   multiline?: false
+  disabled?: boolean
 }
 
 export interface ShortTextInputProps {

--- a/packages/schemas/types/lib/tables.d.ts
+++ b/packages/schemas/types/lib/tables.d.ts
@@ -48,4 +48,5 @@ export interface TableInnerProps {
   wrap?: boolean
   maxWidthVariant?: 'viewportWidth' | 'textWidth'
   minWidthVariant?: 'auto' | 'fill'
+  loading?: boolean
 }

--- a/packages/schemas/types/media/Loading.d.ts
+++ b/packages/schemas/types/media/Loading.d.ts
@@ -1,0 +1,18 @@
+import { MediaProps } from './media-properties'
+
+interface SpinnerProps extends MediaProps {
+  loading: {
+    variant: 'spinner'
+  }
+}
+
+// todo: implement progress bar (OfficeDev/fluent-blocks#167)
+
+// interface ProgressBarProps extends MediaProps {
+//   loading: {
+//     variant: 'progressBar'
+//     progress: number
+//   }
+// }
+
+export type LoadingProps = SpinnerProps /* | ProgressBarProps */

--- a/packages/schemas/types/media/index.d.ts
+++ b/packages/schemas/types/media/index.d.ts
@@ -1,6 +1,7 @@
 export * from './Chart'
 export * from './Code'
 export * from './Illustration'
+export * from './Loading'
 export * from './ThemedImage'
 export * from './Medium'
 export * from './media-properties'


### PR DESCRIPTION
This PR resolves #169 and resolves #168.

This PR also adds a loading state to Table and List. Currently this only replaces the rows node with a Spinner from v9, however in the future it could become a shimmer / skeleton.