### PR TITLE
Fix DescriptionList types & props

### DIFF
--- a/.changeset/gold-months-care.md
+++ b/.changeset/gold-months-care.md
@@ -1,0 +1,6 @@
+---
+'@fluent-blocks/react': patch
+'@fluent-blocks/schemas': patch
+---
+
+Fixed DescriptionList’s types. Also adjust props for Layout and add sizeVariant prop to DescriptionList.

--- a/packages/react/src/blocks/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/blocks/DescriptionList/DescriptionList.tsx
@@ -1,19 +1,23 @@
 import { ReactElement } from 'react'
-import { makeStyles, mergeClasses as cx } from '@fluentui/react-components'
+
 import {
+  DescriptionListItemProps as NaturalDescriptionListItemProps,
   DescriptionListProps as NaturalDescriptionListProps,
-  DescriptionListItemProps,
 } from '@fluent-blocks/schemas'
+import { mergeClasses as cx, makeStyles } from '@fluentui/react-components'
 
 import { InlineContent, InlineSequenceOrString } from '../../inlines'
 import { key, sx, useCommonStyles, useTextBlockStyles } from '../../lib'
 
+export interface DescriptionListItemProps
+  extends Omit<NaturalDescriptionListItemProps, 'title' | 'description'> {
+  title: InlineSequenceOrString
+  description: InlineSequenceOrString
+}
+
 export interface DescriptionListProps
   extends Omit<NaturalDescriptionListProps, 'descriptionList'> {
-  descriptionList: (DescriptionListItemProps & {
-    title: InlineSequenceOrString
-    description: InlineSequenceOrString
-  })[]
+  descriptionList: DescriptionListItemProps[]
 }
 
 const useDescriptionListStyles = makeStyles({

--- a/packages/react/src/blocks/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/blocks/DescriptionList/DescriptionList.tsx
@@ -6,13 +6,16 @@ import {
 } from '@fluent-blocks/schemas'
 import { mergeClasses as cx, makeStyles } from '@fluentui/react-components'
 
-import { InlineContent, InlineSequenceOrString } from '../../inlines'
+import {
+  DescribedInlineContent,
+  DescribedInlineSequenceOrString,
+} from '../../inlines'
 import { key, sx, useCommonStyles, useTextBlockStyles } from '../../lib'
 
 export interface DescriptionListItemProps
   extends Omit<NaturalDescriptionListItemProps, 'title' | 'description'> {
-  title: InlineSequenceOrString
-  description: InlineSequenceOrString
+  title: DescribedInlineSequenceOrString
+  description: DescribedInlineSequenceOrString
 }
 
 export interface DescriptionListProps
@@ -56,7 +59,7 @@ export const DescriptionList = ({
       {descriptionList.map((item) => (
         <div key={key(item)} className={descriptionListStyles.listItem}>
           <dt className={descriptionListStyles.itemTitle}>
-            <InlineContent inlines={item.title} />
+            <DescribedInlineContent inlines={item.title} />
           </dt>
           <dd
             className={cx(
@@ -64,7 +67,7 @@ export const DescriptionList = ({
               descriptionListStyles.itemDescription
             )}
           >
-            <InlineContent inlines={item.description} />
+            <DescribedInlineContent inlines={item.description} />
           </dd>
         </div>
       ))}

--- a/packages/react/src/blocks/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/blocks/DescriptionList/DescriptionList.tsx
@@ -34,13 +34,14 @@ const useDescriptionListStyles = makeStyles({
   },
   itemDescription: {
     order: 0,
-    fontSize: '1.5rem',
-    lineHeight: 4 / 3,
     marginLeft: 0,
   },
 })
 
-export const DescriptionList = ({ descriptionList }: DescriptionListProps) => {
+export const DescriptionList = ({
+  descriptionList,
+  sizeVariant = 1,
+}: DescriptionListProps) => {
   const commonStyles = useCommonStyles()
   const textBlockStyles = useTextBlockStyles()
   const descriptionListStyles = useDescriptionListStyles()
@@ -57,7 +58,12 @@ export const DescriptionList = ({ descriptionList }: DescriptionListProps) => {
           <dt className={descriptionListStyles.itemTitle}>
             <InlineContent inlines={item.title} />
           </dt>
-          <dd className={descriptionListStyles.itemDescription}>
+          <dd
+            className={cx(
+              textBlockStyles[`h${sizeVariant}`],
+              descriptionListStyles.itemDescription
+            )}
+          >
             <InlineContent inlines={item.description} />
           </dd>
         </div>

--- a/packages/react/src/blocks/Layout/Layout.tsx
+++ b/packages/react/src/blocks/Layout/Layout.tsx
@@ -32,7 +32,9 @@ const useLayoutStyles = makeStyles({
   'flex--broad': {},
 })
 
-export const Layout = ({ layout: { variant, items } }: LayoutProps) => {
+export const Layout = ({
+  layout: { variant = 'grid', items },
+}: LayoutProps) => {
   const styles = useLayoutStyles()
   const $layout = useRef<HTMLElement | null>(null)
   const [isBroad, setIsBroad] = useState(false)

--- a/packages/schemas/types/blocks/DescriptionList.d.ts
+++ b/packages/schemas/types/blocks/DescriptionList.d.ts
@@ -7,4 +7,5 @@ export interface DescriptionListItemProps {
 
 export interface DescriptionListProps {
   descriptionList: DescriptionListItemProps[]
+  sizeVariant?: 1 | 2 | 3 | '1' | '2' | '3'
 }

--- a/packages/schemas/types/blocks/DescriptionList.d.ts
+++ b/packages/schemas/types/blocks/DescriptionList.d.ts
@@ -1,8 +1,8 @@
-import { InlineSequenceOrString } from '../inlines'
+import { DescribedInlineSequenceOrString } from '../inlines'
 
 export interface DescriptionListItemProps {
-  title: InlineSequenceOrString
-  description: InlineSequenceOrString
+  title: DescribedInlineSequenceOrString
+  description: DescribedInlineSequenceOrString
 }
 
 export interface DescriptionListProps {

--- a/packages/schemas/types/blocks/Layout.d.ts
+++ b/packages/schemas/types/blocks/Layout.d.ts
@@ -12,7 +12,7 @@ export interface LayoutItemProps {
 
 export interface LayoutProps {
   layout: {
-    variant: LayoutVariant
+    variant?: LayoutVariant
     items: LayoutItemProps[]
   }
 }


### PR DESCRIPTION
This PR fixes DescriptionList’s types.

This PR also:
- adds `sizeVariant` to DescriptionList to allow developers to adjust the size of each description (between sizes for h1, h2, and h3)
- makes `variant` optional for Layout, defaulting to `grid`.