### PR TITLE
Extend Card titles

### DIFF
--- a/.changeset/beige-elephants-juggle.md
+++ b/.changeset/beige-elephants-juggle.md
@@ -1,0 +1,6 @@
+---
+'@fluent-blocks/react': minor
+'@fluent-blocks/schemas': minor
+---
+
+Allow described inlines in Card titles. Allow heading level prop for Card titles.

--- a/packages/react/src/blocks/Card/Card.tsx
+++ b/packages/react/src/blocks/Card/Card.tsx
@@ -107,7 +107,7 @@ export const Card = ({ card, contextualVariant = 'block' }: CardProps) => {
         >
           <Heading
             paragraph={card.title}
-            level={3}
+            level={card.level || 3}
             contextualVariant="card"
             contextualId={id}
           />

--- a/packages/react/src/props/cards.ts
+++ b/packages/react/src/props/cards.ts
@@ -9,7 +9,7 @@ import {
   TablePropsOrElement,
   TabsPropsOrElement,
 } from '../blocks'
-import { InlineSequenceOrString } from '../inlines'
+import { DescribedInlineSequenceOrString } from '../inlines'
 import { EscapeElement } from '../lib'
 import { MenuActionSequence } from './menus'
 
@@ -27,7 +27,7 @@ export type CardContentItemSequence = CardContentItemEntity[]
 
 export interface CardProps extends Omit<NaturalCardProps, 'card'> {
   card: Omit<NaturalCardProps['card'], 'title' | 'actions' | 'body'> & {
-    title: InlineSequenceOrString
+    title: DescribedInlineSequenceOrString
     actions?: MenuActionSequence
     body: CardContentItemSequence
   }

--- a/packages/schemas/types/blocks/Card.d.ts
+++ b/packages/schemas/types/blocks/Card.d.ts
@@ -1,7 +1,8 @@
-import { InlineSequenceOrString } from '../inlines'
+import { DescribedInlineSequenceOrString } from '../inlines'
 import { MenuActionSequence } from '../lib/menu'
 import { DescriptionListProps } from './DescriptionList'
 import { FigureProps } from './Figure'
+import { HeadingLevel } from './Heading'
 import { ParagraphProps } from './Paragraph'
 import { ShortInputsProps } from './ShortInputs'
 import { TableProps } from './Table'
@@ -19,7 +20,8 @@ export type CardContentItemSequence = CardContentItemEntity[]
 
 export interface CardProps {
   card: {
-    title: InlineSequenceOrString
+    title: DescribedInlineSequenceOrString
+    level?: HeadingLevel
     titleVisuallyHidden?: boolean
     actions?: MenuActionSequence
     body: CardContentItemSequence


### PR DESCRIPTION
This PR extends Card titles:
- `level` can be specified for the title heading level
- the `title` prop now supports described inlines