### PR TITLE
Allow Links to defer to action handlers even with href

### DIFF
--- a/.changeset/thin-beds-shop.md
+++ b/.changeset/thin-beds-shop.md
@@ -1,0 +1,5 @@
+---
+'@fluent-blocks/react': minor
+---
+
+Add preferActionHandler to React package Anchor props to prevent navigation and use onAction where possible.


### PR DESCRIPTION
This PR adds nuance to `AnchorProps`; if the developer specifies `preferActionHandler: true`, even if Fluent Blocks would render an anchor, it will use `event.preventDefault()` to prevent navigation and defer to the action handler.